### PR TITLE
Register additional services in generic WithConnectionTo [#49]

### DIFF
--- a/src/Silverback.Integration.Kafka/Messaging/Configuration/KafkaBrokerOptionsConfigurator.cs
+++ b/src/Silverback.Integration.Kafka/Messaging/Configuration/KafkaBrokerOptionsConfigurator.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2020 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using Silverback.Messaging.Behaviors;
+using Silverback.Messaging.Broker;
+
+namespace Silverback.Messaging.Configuration
+{
+    public class KafkaBrokerOptionsConfigurator : IBrokerOptionsConfigurator<KafkaBroker>
+    {
+        public void Configure(ISilverbackBuilder silverbackBuilder, BrokerOptionsBuilder brokerOptionsBuilder)
+        {
+            silverbackBuilder.AddSingletonBehavior<KafkaMessageKeyBehavior>();
+        }
+    }
+}

--- a/src/Silverback.Integration.Kafka/Messaging/Configuration/SilverbackBuilderExtensions.cs
+++ b/src/Silverback.Integration.Kafka/Messaging/Configuration/SilverbackBuilderExtensions.cs
@@ -2,7 +2,6 @@
 // This code is licensed under MIT license (see LICENSE file for details)
 
 using System;
-using Silverback.Messaging.Behaviors;
 using Silverback.Messaging.Broker;
 using Silverback.Messaging.Configuration;
 
@@ -19,13 +18,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns></returns>
         public static ISilverbackBuilder WithConnectionToKafka(
             this ISilverbackBuilder builder,
-            Action<BrokerOptionsBuilder> optionsAction = null)
-        {
+            Action<BrokerOptionsBuilder> optionsAction = null) =>
             builder.WithConnectionTo<KafkaBroker>(optionsAction);
-
-            builder.AddSingletonBehavior<KafkaMessageKeyBehavior>();
-
-            return builder;
-        }
     }
 }

--- a/src/Silverback.Integration.Kafka/Messaging/Messages/KafkaPartitionsAssignedEvent.cs
+++ b/src/Silverback.Integration.Kafka/Messaging/Messages/KafkaPartitionsAssignedEvent.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Silverback.Messaging.Broker;
 
 namespace Silverback.Messaging.Messages
 {

--- a/src/Silverback.Integration.Kafka/Messaging/Messages/KafkaPartitionsRevokedEvent.cs
+++ b/src/Silverback.Integration.Kafka/Messaging/Messages/KafkaPartitionsRevokedEvent.cs
@@ -2,7 +2,6 @@
 // This code is licensed under MIT license (see LICENSE file for details)
 
 using System.Collections.Generic;
-using Silverback.Messaging.Broker;
 
 namespace Silverback.Messaging.Messages
 {

--- a/src/Silverback.Integration.RabbitMQ/Messaging/Configuration/RabbitBrokerOptionsConfigurator.cs
+++ b/src/Silverback.Integration.RabbitMQ/Messaging/Configuration/RabbitBrokerOptionsConfigurator.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2020 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using Microsoft.Extensions.DependencyInjection;
+using Silverback.Messaging.Behaviors;
+using Silverback.Messaging.Broker;
+
+namespace Silverback.Messaging.Configuration
+{
+    public class RabbitBrokerOptionsConfigurator : IBrokerOptionsConfigurator<RabbitBroker>
+    {
+        public void Configure(ISilverbackBuilder silverbackBuilder, BrokerOptionsBuilder brokerOptionsBuilder)
+        {
+            silverbackBuilder.Services
+                .AddSingleton<IRabbitConnectionFactory, RabbitConnectionFactory>()
+                .AddSingletonBehavior<RabbitRoutingKeyBehavior>();
+        }
+    }
+}

--- a/src/Silverback.Integration.RabbitMQ/Messaging/Configuration/SilverbackBuilderExtensions.cs
+++ b/src/Silverback.Integration.RabbitMQ/Messaging/Configuration/SilverbackBuilderExtensions.cs
@@ -2,7 +2,6 @@
 // This code is licensed under MIT license (see LICENSE file for details)
 
 using System;
-using Silverback.Messaging.Behaviors;
 using Silverback.Messaging.Broker;
 using Silverback.Messaging.Configuration;
 
@@ -19,15 +18,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns></returns>
         public static ISilverbackBuilder WithConnectionToRabbit(
             this ISilverbackBuilder builder,
-            Action<BrokerOptionsBuilder> optionsAction = null)
-        {
+            Action<BrokerOptionsBuilder> optionsAction = null) =>
             builder.WithConnectionTo<RabbitBroker>(optionsAction);
-
-            builder.Services.AddSingleton<IRabbitConnectionFactory, RabbitConnectionFactory>();
-
-            builder.AddSingletonBehavior<RabbitRoutingKeyBehavior>();
-
-            return builder;
-        }
     }
 }

--- a/src/Silverback.Integration/Messaging/Configuration/IBrokerOptionsConfigurator.cs
+++ b/src/Silverback.Integration/Messaging/Configuration/IBrokerOptionsConfigurator.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2020 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System.Diagnostics.CodeAnalysis;
+using Silverback.Messaging.Broker;
+
+namespace Silverback.Messaging.Configuration
+{
+    [SuppressMessage("ReSharper", "UnusedTypeParameter")]
+    public interface IBrokerOptionsConfigurator<TBroker> where TBroker : IBroker
+    {
+        /// <summary>
+        ///     Called when registered the broker to configure the broker-specific services and options
+        ///     (e.g. behaviors).
+        /// </summary>
+        void Configure(ISilverbackBuilder silverbackBuilder, BrokerOptionsBuilder brokerOptionsBuilder);
+    }
+}

--- a/src/Silverback.Integration/Messaging/Configuration/SilverbackBuilderExtensions.cs
+++ b/src/Silverback.Integration/Messaging/Configuration/SilverbackBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // This code is licensed under MIT license (see LICENSE file for details)
 
 using System;
+using System.Linq;
 using Silverback.Messaging.Broker;
 using Silverback.Messaging.Configuration;
 using Silverback.Messaging.Diagnostics;
@@ -12,6 +13,8 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class SilverbackBuilderExtensions
     {
+        #region WithConnectionTo
+
         /// <summary>
         ///     Registers the message broker of the specified type.
         /// </summary>
@@ -33,10 +36,134 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddSingletonBrokerBehavior<ActivityConsumerBehavior>();
 
             var options = new BrokerOptionsBuilder(builder);
+            FindOptionsConfigurator<T>()?.Configure(builder, options);
             optionsAction?.Invoke(options);
             options.CompleteWithDefaults();
 
             return builder;
         }
+
+        private static IBrokerOptionsConfigurator<TBroker> FindOptionsConfigurator<TBroker>()
+            where TBroker : IBroker
+        {
+            var type = typeof(TBroker).Assembly.GetTypes()
+                .FirstOrDefault(t => typeof(IBrokerOptionsConfigurator<TBroker>).IsAssignableFrom(t));
+
+            if (type == null)
+                return null;
+
+            return (IBrokerOptionsConfigurator<TBroker> )Activator.CreateInstance(type);
+        }
+
+        #endregion
+        
+                #region RegisterConfigurator
+
+        /// <summary>
+        ///     Adds an <see cref="IEndpointsConfigurator" /> to be used to setup the broker endpoints.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <typeparam name="TConfigurator">The type of the <see cref="IEndpointsConfigurator" /> to add.</typeparam>
+        /// <returns></returns>
+        public static ISilverbackBuilder AddEndpointsConfigurator<TConfigurator>(this ISilverbackBuilder builder)
+            where TConfigurator : class, IEndpointsConfigurator
+        {
+            builder.Services.AddEndpointsConfigurator<TConfigurator>();
+            return builder;
+        }
+
+        /// <summary>
+        ///     Adds an <see cref="IEndpointsConfigurator" /> to be used to setup the broker endpoints.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="configuratorType">The type of the <see cref="IEndpointsConfigurator" /> to add.</param>
+        /// <returns></returns>
+        public static ISilverbackBuilder AddEndpointsConfigurator(
+            this ISilverbackBuilder builder,
+            Type configuratorType)
+        {
+            builder.Services.AddEndpointsConfigurator(configuratorType);
+            return builder;
+        }
+
+        /// <summary>
+        ///     Adds an <see cref="IEndpointsConfigurator" /> to be used to setup the broker endpoints.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="implementationFactory">The factory that creates the <see cref="IEndpointsConfigurator" /> to add.</param>
+        /// <returns></returns>
+        public static ISilverbackBuilder AddEndpointsConfigurator(
+            this ISilverbackBuilder builder,
+            Func<IServiceProvider, IEndpointsConfigurator> implementationFactory)
+        {
+            builder.Services.AddEndpointsConfigurator(implementationFactory);
+            return builder;
+        }
+
+        #endregion
+
+        #region BrokerBehaviors (AddSingletonBrokerBehavior)
+
+        /// <summary>
+        ///     Adds a singleton behavior of the type specified in <paramref name="behaviorType" /> to the
+        ///     specified <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection" />.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="behaviorType">The type of the behavior to register and the implementation to use.</param>
+        /// <returns>A reference to this instance after the operation has completed.</returns>
+        public static ISilverbackBuilder AddSingletonBrokerBehavior(this ISilverbackBuilder builder, Type behaviorType)
+        {
+            builder.Services.AddSingletonBrokerBehavior(behaviorType);
+            return builder;
+        }
+
+        /// <summary>
+        ///     Adds a singleton behavior of the type specified in <typeparamref name="TBehavior" /> to the
+        ///     specified <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection" />.
+        /// </summary>
+        /// <typeparam name="TBehavior">The type of the behavior to add.</typeparam>
+        /// <param name="builder"></param>
+        /// <returns>A reference to this instance after the operation has completed.</returns>
+        public static ISilverbackBuilder AddSingletonBrokerBehavior<TBehavior>(this ISilverbackBuilder builder)
+            where TBehavior : class, IBrokerBehavior
+        {
+            builder.Services.AddSingletonBrokerBehavior<TBehavior>();
+            return builder;
+        }
+
+        /// <summary>
+        ///     Adds a singleton behavior with a
+        ///     factory specified in <paramref name="implementationFactory" /> to the
+        ///     specified <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection" />.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="implementationFactory">The factory that creates the service.</param>
+        /// <returns>A reference to this instance after the operation has completed.</returns>
+        public static ISilverbackBuilder AddSingletonBrokerBehavior(
+            this ISilverbackBuilder builder,
+            Func<IServiceProvider, IBrokerBehavior> implementationFactory)
+        {
+            builder.Services.AddSingletonBrokerBehavior(implementationFactory);
+            return builder;
+        }
+
+        /// <summary>
+        ///     Adds a singleton behavior with an
+        ///     instance specified in <paramref name="implementationInstance" /> to the
+        ///     specified <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection" />.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="implementationInstance">The instance of the service.</param>
+        /// <returns>A reference to this instance after the operation has completed.</returns>
+        /// <seealso cref="F:Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton" />
+        public static ISilverbackBuilder AddSingletonBrokerBehavior(
+            this ISilverbackBuilder builder,
+            IBrokerBehavior implementationInstance)
+        {
+            builder.Services.AddSingletonBrokerBehavior(implementationInstance);
+            return builder;
+        }
+
+        #endregion
     }
 }

--- a/src/Silverback.Integration/Messaging/Connectors/OutboundQueueWorker.cs
+++ b/src/Silverback.Integration/Messaging/Connectors/OutboundQueueWorker.cs
@@ -83,7 +83,7 @@ namespace Silverback.Messaging.Connectors
             catch (Exception ex)
             {
                 _messageLogger.LogError(_logger, ex, "Failed to publish queued message.",
-                    new OutboundEnvelope(message.Content, message.Headers, message.Endpoint, false));
+                    new OutboundEnvelope(message.Content, message.Headers, message.Endpoint));
 
                 await queue.Retry(message);
 

--- a/tests/Silverback.Integration.Kafka.Tests/Messaging/Configuration/SilverbackBuilderExtensionsTests.cs
+++ b/tests/Silverback.Integration.Kafka.Tests/Messaging/Configuration/SilverbackBuilderExtensionsTests.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Silverback.Messaging.Broker;
+using Silverback.Messaging.Configuration;
+using Xunit;
+
+namespace Silverback.Tests.Integration.Kafka.Messaging.Configuration
+{
+    public class SilverbackBuilderExtensionsTests
+    {
+        [Fact]
+        public void WithConnectionTo_GenericAndSpecificVersions_BehavesTheSame()
+        {
+            var servicesGeneric = new ServiceCollection();
+            var servicesSpecific = new ServiceCollection();
+            
+            new SilverbackBuilder(servicesGeneric).WithConnectionTo<KafkaBroker>();
+            new SilverbackBuilder(servicesSpecific).WithConnectionToKafka();
+
+            servicesGeneric.Count.Should().Be(servicesSpecific.Count);
+        }
+    }
+}

--- a/tests/Silverback.Integration.RabbitMQ.Tests/Messaging/Configuration/SilverbackBuilderExtensionsTests.cs
+++ b/tests/Silverback.Integration.RabbitMQ.Tests/Messaging/Configuration/SilverbackBuilderExtensionsTests.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Silverback.Messaging.Broker;
+using Silverback.Messaging.Configuration;
+using Xunit;
+
+namespace Silverback.Tests.Integration.RabbitMQ.Messaging.Configuration
+{
+    public class SilverbackBuilderExtensionsTests
+    {
+        [Fact]
+        public void WithConnectionTo_GenericAndSpecificVersions_BehavesTheSame()
+        {
+            var servicesGeneric = new ServiceCollection();
+            var servicesSpecific = new ServiceCollection();
+            
+            new SilverbackBuilder(servicesGeneric).WithConnectionTo<RabbitBroker>();
+            new SilverbackBuilder(servicesSpecific).WithConnectionToRabbit();
+
+            servicesGeneric.Count.Should().Be(servicesSpecific.Count);
+        }
+    }
+}

--- a/tests/Silverback.Integration.Tests/Messaging/Configuration/SilverbackBuilderExtensionsTests.cs
+++ b/tests/Silverback.Integration.Tests/Messaging/Configuration/SilverbackBuilderExtensionsTests.cs
@@ -39,5 +39,19 @@ namespace Silverback.Tests.Integration.Messaging.Configuration
             registeredBehaviors.Should()
                 .Contain(x => x.GetType() == typeof(ActivityConsumerBehavior));
         }
+
+        [Fact]
+        public void WithConnectionTo_BrokerOptionsConfiguratorInvoked()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddSilverback()
+                .WithConnectionTo<TestBroker>(options => { })
+                .Services.BuildServiceProvider();
+
+            var registeredBehaviors = serviceProvider.GetServices<IBrokerBehavior>().ToList();
+
+            registeredBehaviors.Should()
+                .Contain(x => x.GetType() == typeof(EmptyBehavior));
+        }
     }
 }

--- a/tests/Silverback.Integration.Tests/Messaging/Connectors/Behaviors/OutboundRoutingBehaviorTests.cs
+++ b/tests/Silverback.Integration.Tests/Messaging/Connectors/Behaviors/OutboundRoutingBehaviorTests.cs
@@ -163,8 +163,7 @@ namespace Silverback.Tests.Integration.Messaging.Connectors.Behaviors
             _routingConfiguration.PublishOutboundMessagesToInternalBus = true;
             _routingConfiguration.Add<TestEventOne>(new TestProducerEndpoint("eventOne"), typeof(OutboundConnector));
 
-            var messages =
-                await _behavior.Handle(new object[] { new TestEventOne(), new TestEventTwo() }, Task.FromResult);
+            await _behavior.Handle(new object[] { new TestEventOne(), new TestEventTwo() }, Task.FromResult);
 
             _testSubscriber.ReceivedMessages.Count.Should().Be(1);
             _testSubscriber.ReceivedMessages.First().Should().BeOfType<TestEventOne>();

--- a/tests/Silverback.Integration.Tests/TestTypes/EmptyBehavior.cs
+++ b/tests/Silverback.Integration.Tests/TestTypes/EmptyBehavior.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2020 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System.Threading.Tasks;
+using Silverback.Messaging.Broker;
+using Silverback.Messaging.Messages;
+
+namespace Silverback.Tests.Integration.TestTypes
+{
+    public class EmptyBehavior : IConsumerBehavior, IProducerBehavior
+    {
+        Task IConsumerBehavior.Handle(RawBrokerEnvelope envelope, RawBrokerMessageHandler next) => next(envelope);
+        Task IProducerBehavior.Handle(RawBrokerEnvelope envelope, RawBrokerMessageHandler next) => next(envelope);
+    }
+}

--- a/tests/Silverback.Integration.Tests/TestTypes/TestBrokerConfigurator.cs
+++ b/tests/Silverback.Integration.Tests/TestTypes/TestBrokerConfigurator.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2020 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using Microsoft.Extensions.DependencyInjection;
+using Silverback.Messaging.Configuration;
+
+namespace Silverback.Tests.Integration.TestTypes
+{
+    public class TestBrokerConfigurator : IBrokerOptionsConfigurator<TestBroker>
+    {
+        public void Configure(ISilverbackBuilder silverbackBuilder, BrokerOptionsBuilder brokerOptionsBuilder)
+        {
+            silverbackBuilder.AddSingletonBrokerBehavior<EmptyBehavior>();
+        }
+    }
+}


### PR DESCRIPTION
This it to avoid issues when the generic `WithConnectionTo<TBroker>` is used by mistake instead of the specific `WithConnectionToKafka`.