### PR TITLE
Fix propagation of Kafka key for messages not generated by Silverback…

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <Description>Silverback is a simple framework to build reactive, event-driven, microservices.</Description>
     <License>MIT</License>
     <Copyright>Copyright (c) 2019 Sergio Aquilini</Copyright>
-    <VersionSuffix>-rc1</VersionSuffix>
+    <VersionSuffix>-rc2</VersionSuffix>
     <BaseVersion>2.0.0$(VersionSuffix)</BaseVersion>
     <ProjectUrl>https://beagle1984.github.io/silverback/</ProjectUrl>
     <RepositoryUrl>https://github.com/BEagle1984/silverback/</RepositoryUrl>

--- a/docs/_docs/0-introduction/003-releases.md
+++ b/docs/_docs/0-introduction/003-releases.md
@@ -4,7 +4,7 @@ permalink: /docs/releases
 toc: true
 ---
 
-## [2.0.0-rc1](https://github.com/BEagle1984/silverback/releases/tag/2.0.0-rc1)
+## [2.0.0-rc2](https://github.com/BEagle1984/silverback/releases/tag/2.0.0-rc2)
 
 ### What's new
 * Created `Silverback.Integration.RabbitMQ` package to connect Silverback with RabbitMQ (see [Connecting to a Message Broker]({{ site.baseurl }}/docs/quickstart/message-broker))

--- a/docs/_docs/3-advanced/350-default-headers.md
+++ b/docs/_docs/3-advanced/350-default-headers.md
@@ -8,16 +8,17 @@ toc: false
 Silverback will add some headers to the produced messages. They may vary depending on the scenario.
 Here is the list of the default headers that may be sent.
 
-Header | Optional | Description
-:-- | :-: | :--
-`x-message-id` | yes | A unique identifier that may be useful for tracing. It may not be present if the produced message isn't implementing `IIntegrationMessage` and no `Id` or `MessageId` property of a supported type is defined.
-`x-message-type` | no | The assembly qualified name of the message type.
-`x-failed-attempts` | yes | If an exception if thrown the failed attempts will be incremented and stored as header. This is necessary for the [error policies]({{ site.baseurl }}/docs/configuration/inbound#error-handling) to work.
-`x-chunk-id` | yes | The unique id of the message chunk, used when [chunking]({{ site.baseurl }}/docs/advanced/chunking) is enabled.
-`x-chunks-count` | yes | The total number of chunks the message was splitted into, used when [chunking]({{ site.baseurl }}/docs/advanced/chunking) is enabled.
-`x-batch-id` | yes | The unique id assigned to the messages batch, used mostly for tracing, when [batch processing]({{ site.baseurl }}/docs/configuration/inbound#batch-processing) is enabled.
-`x-batch-size` | yes | The total number of messages in the batch, used mostly for tracing, when [batch processing]({{ site.baseurl }}/docs/configuration/inbound#batch-processing) is enabled.
-`traceparent` | no | The current `Activity.Id`, used by the `IConsumer` implementation to set the `Activity.ParentId`, thus enabling distributed tracing across the message broker. Note that an `Activity` is automatically started by the default `IProducer` implementation. See [System.Diagnostics documentation](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=netcore-3.1) for details about `Activity` and distributed tracing in asp.net core and [W3C Trace Context proposal](https://www.w3.org/TR/trace-context-1) for details about the headers.
-`tracestate` | yes | The `Activity.TraceStateString`. See also the [W3C Trace Context proposal](https://www.w3.org/TR/trace-context-1) for details.
+Header Key | Constant | Optional | Description
+:-- | :-- | :-: | :--
+`x-message-id` | `MessageHeader.MessageIdKey` | yes | A unique identifier that may be useful for tracing. It may not be present if the produced message isn't implementing `IIntegrationMessage` and no `Id` or `MessageId` property of a supported type is defined.
+`x-message-type` | `MessageHeader.MessageTypeKey` | no | The assembly qualified name of the message type. Used by the default `JsonMessageSerializer`.
+`x-failed-attempts` | `MessageHeader.FailedAttemptsKey` | yes | If an exception if thrown the failed attempts will be incremented and stored as header. This is necessary for the [error policies]({{ site.baseurl }}/docs/configuration/inbound#error-handling) to work.
+`x-source-endpoint` | `MessageHeader.SourceEndpoint` | yes | This will be set by the `Move` is being moved from.
+`x-chunk-id` | `MessageHeader.ChunkIdKey` | yes | The unique id of the message chunk, used when [chunking]({{ site.baseurl }}/docs/advanced/chunking) is enabled.
+`x-chunks-count` | `MessageHeader.ChunksCountKey` | yes | The total number of chunks the message was split into, used when [chunking]({{ site.baseurl }}/docs/advanced/chunking) is enabled.
+`x-batch-id` | `MessageHeader.BatchIdKey` | yes | The unique id assigned to the messages batch, used mostly for tracing, when [batch processing]({{ site.baseurl }}/docs/configuration/inbound#batch-processing) is enabled.
+`x-batch-size` | `MessageHeader.BatchSizeKey` | yes | The total number of messages in the batch, used mostly for tracing, when [batch processing]({{ site.baseurl }}/docs/configuration/inbound#batch-processing) is enabled.
+`traceparent` | _none_ | no | The current `Activity.Id`, used by the `IConsumer` implementation to set the `Activity.ParentId`, thus enabling distributed tracing across the message broker. Note that an `Activity` is automatically started by the default `IProducer` implementation. See [System.Diagnostics documentation](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=netcore-3.1) for details about `Activity` and distributed tracing in asp.net core and [W3C Trace Context proposal](https://www.w3.org/TR/trace-context-1) for details about the headers.
+`tracestate` | _none_  yes | The `Activity.TraceStateString`. See also the [W3C Trace Context proposal](https://www.w3.org/TR/trace-context-1) for details.
 `tracebaggage` | yes | The string representation of the `Activity.Baggage` dictionary. See [System.Diagnostics documentation](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=netcore-3.1) for details.
 `x-kafka-message-key` | yes | When using Kafka, the [kafka message key]({{ site.baseurl }}/docs/kafka/message-key) will also be submitted as header (see [Kafka Message Key (Partitioning)]({{ site.baseurl }}/docs/kafka/message-key) to know how to define a message key)

--- a/src/Silverback.Integration.InMemory/Messaging/Broker/InMemoryConsumer.cs
+++ b/src/Silverback.Integration.InMemory/Messaging/Broker/InMemoryConsumer.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Silverback.Messaging.Messages;
+using System.Linq;
 
 namespace Silverback.Messaging.Broker
 {
@@ -42,6 +43,6 @@ namespace Silverback.Messaging.Broker
         }
 
         internal Task Receive(byte[] message, IEnumerable<MessageHeader> headers, IOffset offset) =>
-            HandleMessage(message, headers, offset);
+            HandleMessage(message, headers.ToList(), offset);
     }
 }

--- a/src/Silverback.Integration.Kafka/Messaging/Behaviors/KafkaMessageKeyBehavior.cs
+++ b/src/Silverback.Integration.Kafka/Messaging/Behaviors/KafkaMessageKeyBehavior.cs
@@ -28,7 +28,7 @@ namespace Silverback.Messaging.Behaviors
             if (key == null)
                 return;
 
-            envelope.Headers.AddOrReplace(KafkaProducer.MessageKeyHeaderKey, key);
+            envelope.Headers.AddOrReplace(KafkaBroker.MessageKeyHeaderKey, key);
         }
     }
 }

--- a/src/Silverback.Integration.Kafka/Messaging/Behaviors/KafkaMessageKeyBehavior.cs
+++ b/src/Silverback.Integration.Kafka/Messaging/Behaviors/KafkaMessageKeyBehavior.cs
@@ -28,7 +28,7 @@ namespace Silverback.Messaging.Behaviors
             if (key == null)
                 return;
 
-            envelope.Headers.AddOrReplace(KafkaBroker.MessageKeyHeaderKey, key);
+            envelope.Headers.AddOrReplace(KafkaMessageHeaders.KafkaMessageKey, key);
         }
     }
 }

--- a/src/Silverback.Integration.Kafka/Messaging/Broker/KafkaBroker.cs
+++ b/src/Silverback.Integration.Kafka/Messaging/Broker/KafkaBroker.cs
@@ -13,6 +13,8 @@ namespace Silverback.Messaging.Broker
     /// </summary>
     public class KafkaBroker : Broker
     {
+        internal const string MessageKeyHeaderKey = "x-kafka-message-key";
+        
         private readonly MessageIdProvider _messageIdProvider;
         private readonly IServiceProvider _serviceProvider;
         private readonly ILoggerFactory _loggerFactory;

--- a/src/Silverback.Integration.Kafka/Messaging/Broker/KafkaBroker.cs
+++ b/src/Silverback.Integration.Kafka/Messaging/Broker/KafkaBroker.cs
@@ -13,8 +13,6 @@ namespace Silverback.Messaging.Broker
     /// </summary>
     public class KafkaBroker : Broker
     {
-        internal const string MessageKeyHeaderKey = "x-kafka-message-key";
-        
         private readonly MessageIdProvider _messageIdProvider;
         private readonly IServiceProvider _serviceProvider;
         private readonly ILoggerFactory _loggerFactory;

--- a/src/Silverback.Integration.Kafka/Messaging/Broker/KafkaConsumer.cs
+++ b/src/Silverback.Integration.Kafka/Messaging/Broker/KafkaConsumer.cs
@@ -98,7 +98,7 @@ namespace Silverback.Messaging.Broker
                 var headers = new MessageHeaderCollection(message.Headers.ToSilverbackHeaders());
                 
                 if (message.Key != null)
-                    headers.AddOrReplace(KafkaBroker.MessageKeyHeaderKey, Encoding.UTF8.GetString(message.Key));
+                    headers.AddOrReplace(KafkaMessageHeaders.KafkaMessageKey, Encoding.UTF8.GetString(message.Key));
                 
                 await HandleMessage(
                     message.Value,

--- a/src/Silverback.Integration.Kafka/Messaging/Broker/KafkaConsumer.cs
+++ b/src/Silverback.Integration.Kafka/Messaging/Broker/KafkaConsumer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Silverback.Messaging.Messages;
@@ -94,9 +95,14 @@ namespace Silverback.Messaging.Broker
                 _messagesSinceCommit++;
                 offset = new KafkaOffset(tpo);
 
+                var headers = new MessageHeaderCollection(message.Headers.ToSilverbackHeaders());
+                
+                if (message.Key != null)
+                    headers.AddOrReplace(KafkaBroker.MessageKeyHeaderKey, Encoding.UTF8.GetString(message.Key));
+                
                 await HandleMessage(
                     message.Value,
-                    message.Headers.ToSilverbackHeaders(),
+                    headers,
                     offset);
             }
             catch (Exception ex)

--- a/src/Silverback.Integration.Kafka/Messaging/Broker/KafkaProducer.cs
+++ b/src/Silverback.Integration.Kafka/Messaging/Broker/KafkaProducer.cs
@@ -47,7 +47,7 @@ namespace Silverback.Messaging.Broker
             {
                 var kafkaMessage = new Confluent.Kafka.Message<byte[], byte[]>
                 {
-                    Key = GetKafkaMessageKey(envelope.Headers),
+                    Key = GetKafkaKeyAndRemoveHeader(envelope.Headers),
                     Value = envelope.RawMessage
                 };
 
@@ -76,10 +76,10 @@ namespace Silverback.Messaging.Broker
             }
         }
 
-        private byte[] GetKafkaMessageKey(MessageHeaderCollection headers)
+        private byte[] GetKafkaKeyAndRemoveHeader(MessageHeaderCollection headers)
         {
             var kafkaKeyHeader = headers
-                ?.FirstOrDefault(header => header.Key == KafkaBroker.MessageKeyHeaderKey);
+                ?.FirstOrDefault(header => header.Key == KafkaMessageHeaders.KafkaMessageKey);
 
             if (kafkaKeyHeader != null)
             {

--- a/src/Silverback.Integration.Kafka/Messaging/Messages/HeadersExtensions.cs
+++ b/src/Silverback.Integration.Kafka/Messaging/Messages/HeadersExtensions.cs
@@ -19,7 +19,7 @@ namespace Silverback.Messaging.Messages
             return kafkaHeaders;
         }
 
-        public static IEnumerable<MessageHeader> ToSilverbackHeaders(this Confluent.Kafka.Headers kafkaHeaders) =>
+        public static IReadOnlyCollection<MessageHeader> ToSilverbackHeaders(this Confluent.Kafka.Headers kafkaHeaders) =>
             kafkaHeaders.Select(kafkaHeader =>
                     new MessageHeader(
                         kafkaHeader.Key,

--- a/src/Silverback.Integration.Kafka/Messaging/Messages/KafkaMessageHeaders.cs
+++ b/src/Silverback.Integration.Kafka/Messaging/Messages/KafkaMessageHeaders.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2020 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+namespace Silverback.Messaging.Messages
+{
+    public static class KafkaMessageHeaders
+    {
+        /// <summary>
+        ///     The header that will be filled with the Kafka key (if specified for the message being consumed).
+        /// </summary>
+        public const string KafkaMessageKey = "x-kafka-message-key";
+    }
+}

--- a/src/Silverback.Integration.RabbitMQ/Messaging/Messages/HeadersExtensions.cs
+++ b/src/Silverback.Integration.RabbitMQ/Messaging/Messages/HeadersExtensions.cs
@@ -16,7 +16,7 @@ namespace Silverback.Messaging.Messages
                 header => header.Key,
                 header => (object) Encoding.GetBytes(header.Value));
 
-        public static IEnumerable<MessageHeader> ToSilverbackHeaders(this IDictionary<string, object> rabbitHeaders) =>
+        public static IReadOnlyCollection<MessageHeader> ToSilverbackHeaders(this IDictionary<string, object> rabbitHeaders) =>
             rabbitHeaders.Select(rabbitHeader =>
                     new MessageHeader(
                         rabbitHeader.Key,

--- a/src/Silverback.Integration/Messaging/Batch/MessageBatch.cs
+++ b/src/Silverback.Integration/Messaging/Batch/MessageBatch.cs
@@ -149,8 +149,8 @@ namespace Silverback.Messaging.Batch
         {
             foreach (var envelope in envelopes)
             {
-                envelope.Headers.AddOrReplace(MessageHeader.BatchIdKey, CurrentBatchId);
-                envelope.Headers.AddOrReplace(MessageHeader.BatchSizeKey, CurrentSize);
+                envelope.Headers.AddOrReplace(DefaultMessageHeaders.BatchId, CurrentBatchId);
+                envelope.Headers.AddOrReplace(DefaultMessageHeaders.BatchSize, CurrentSize);
             }
         }
 

--- a/src/Silverback.Integration/Messaging/Broker/Consumer.cs
+++ b/src/Silverback.Integration/Messaging/Broker/Consumer.cs
@@ -63,7 +63,7 @@ namespace Silverback.Messaging.Broker
         /// <param name="headers">The headers of the consumed message.</param>
         /// <param name="offset">The offset of the consumed message.</param>
         /// <returns></returns>
-        protected virtual async Task HandleMessage(byte[] message, IEnumerable<MessageHeader> headers, IOffset offset)
+        protected virtual async Task HandleMessage(byte[] message, IReadOnlyCollection<MessageHeader> headers, IOffset offset)
         {
             if (Received == null)
                 throw new InvalidOperationException(

--- a/src/Silverback.Integration/Messaging/Connectors/InboundConnector.cs
+++ b/src/Silverback.Integration/Messaging/Connectors/InboundConnector.cs
@@ -76,7 +76,7 @@ namespace Silverback.Messaging.Connectors
             IInboundEnvelope envelope,
             IServiceProvider serviceProvider)
         {
-            if (!envelope.Headers.Contains(MessageHeader.ChunkIdKey))
+            if (!envelope.Headers.Contains(DefaultMessageHeaders.ChunkId))
                 return envelope;
 
             var completeMessage = await serviceProvider.GetRequiredService<ChunkConsumer>().JoinIfComplete(envelope);

--- a/src/Silverback.Integration/Messaging/Diagnostics/ActivityExtensions.cs
+++ b/src/Silverback.Integration/Messaging/Diagnostics/ActivityExtensions.cs
@@ -27,17 +27,17 @@ namespace Silverback.Messaging.Diagnostics
                 throw new InvalidOperationException(
                     "Activity.Id is null. Consider to start a new activity, before calling this method.");
 
-            headers.Add(new MessageHeader(DiagnosticsConstants.TraceIdHeaderKey, activity.Id));
+            headers.Add(new MessageHeader(DefaultMessageHeaders.TraceId, activity.Id));
 
             var traceState = activity.TraceStateString;
             if (traceState != null)
             {
-                headers.Add(DiagnosticsConstants.TraceStateHeaderKey, traceState);
+                headers.Add(DefaultMessageHeaders.TraceState, traceState);
             }
 
             if (activity.Baggage.Any())
             {
-                headers.Add(new MessageHeader(DiagnosticsConstants.TraceBaggageHeaderKey,
+                headers.Add(new MessageHeader(DefaultMessageHeaders.TraceBaggage,
                     BaggageConverter.Serialize(activity.Baggage)));
             }
         }
@@ -45,14 +45,14 @@ namespace Silverback.Messaging.Diagnostics
         // See https://github.com/aspnet/AspNetCore/blob/master/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
         public static void InitFromMessageHeaders(this Activity activity, MessageHeaderCollection headers)
         {
-            var traceId = headers.GetValue(DiagnosticsConstants.TraceIdHeaderKey);
+            var traceId = headers.GetValue(DefaultMessageHeaders.TraceId);
             if (!string.IsNullOrEmpty(traceId))
             {
                 // This will reflect, that the current activity is a child of the activity
                 // which is represented in the message.
                 activity.SetParentId(traceId);
 
-                var traceState = headers.GetValue(DiagnosticsConstants.TraceStateHeaderKey);
+                var traceState = headers.GetValue(DefaultMessageHeaders.TraceState);
                 if (!string.IsNullOrEmpty(traceState))
                 {
                     activity.TraceStateString = traceState;
@@ -60,7 +60,7 @@ namespace Silverback.Messaging.Diagnostics
 
                 // We expect baggage to be empty by default.
                 // Only very advanced users will be using it in near future, we encourage them to keep baggage small (few items).
-                var baggage = headers.GetValue(DiagnosticsConstants.TraceBaggageHeaderKey);
+                var baggage = headers.GetValue(DefaultMessageHeaders.TraceBaggage);
                 if (BaggageConverter.TryDeserialize(baggage, out var baggageItems))
                 {
                     activity.AddBaggageRange(baggageItems);

--- a/src/Silverback.Integration/Messaging/Diagnostics/DiagnosticsConstants.cs
+++ b/src/Silverback.Integration/Messaging/Diagnostics/DiagnosticsConstants.cs
@@ -9,13 +9,5 @@ namespace Silverback.Messaging.Diagnostics
     {
         public static readonly string ActivityNameMessageConsuming = typeof(Consumer).FullName + "-ConsumeMessage";
         public static readonly string ActivityNameMessageProducing = typeof(Producer).FullName + "-ProduceMessage";
-
-        public const string
-            TraceIdHeaderKey = "traceparent"; // According https://www.w3.org/TR/trace-context-1/#traceparent-header
-
-        public const string
-            TraceStateHeaderKey = "tracestate"; // According https://www.w3.org/TR/trace-context-1/#tracestate-header
-
-        public const string TraceBaggageHeaderKey = "tracebaggage"; // Not part of the w3c standard
     }
 }

--- a/src/Silverback.Integration/Messaging/ErrorHandling/ErrorPolicyBase.cs
+++ b/src/Silverback.Integration/Messaging/ErrorHandling/ErrorPolicyBase.cs
@@ -135,7 +135,7 @@ namespace Silverback.Messaging.ErrorHandling
                 return false;
             }
 
-            var failedAttempts = envelope.Headers.GetValueOrDefault<int>(MessageHeader.FailedAttemptsKey);
+            var failedAttempts = envelope.Headers.GetValueOrDefault<int>(DefaultMessageHeaders.FailedAttempts);
             if (MaxFailedAttemptsSetting >= 0 && failedAttempts > MaxFailedAttemptsSetting)
             {
                 _messageLogger.LogTrace(_logger,

--- a/src/Silverback.Integration/Messaging/ErrorHandling/ErrorPolicyHelper.cs
+++ b/src/Silverback.Integration/Messaging/ErrorHandling/ErrorPolicyHelper.cs
@@ -44,7 +44,8 @@ namespace Silverback.Messaging.ErrorHandling
 
         private int GetAttemptNumber(IReadOnlyCollection<IInboundEnvelope> envelopes)
         {
-            var minAttempts = envelopes.Min(m => m.Headers.GetValueOrDefault<int>(MessageHeader.FailedAttemptsKey));
+            var minAttempts = envelopes.Min(m => 
+                m.Headers.GetValueOrDefault<int>(DefaultMessageHeaders.FailedAttempts));
 
             // Uniform failed attempts, just in case (mostly for consistent logging)
             UpdateFailedAttemptsHeader(envelopes, minAttempts);
@@ -91,9 +92,9 @@ namespace Silverback.Messaging.ErrorHandling
             envelopes?.ForEach(msg =>
             {
                 if (attempt == 0)
-                    msg.Headers.Remove(MessageHeader.FailedAttemptsKey);
+                    msg.Headers.Remove(DefaultMessageHeaders.FailedAttempts);
                 else
-                    msg.Headers.AddOrReplace(MessageHeader.FailedAttemptsKey, attempt);
+                    msg.Headers.AddOrReplace(DefaultMessageHeaders.FailedAttempts, attempt);
             });
     }
 }

--- a/src/Silverback.Integration/Messaging/ErrorHandling/MoveMessageErrorPolicy.cs
+++ b/src/Silverback.Integration/Messaging/ErrorHandling/MoveMessageErrorPolicy.cs
@@ -62,7 +62,7 @@ namespace Silverback.Messaging.ErrorHandling
 
         private void PublishToNewEndpoint(IInboundEnvelope envelope, Exception exception)
         {
-            envelope.Headers.AddOrReplace(MessageHeader.SourceEndpointKey, envelope.Endpoint?.Name);
+            envelope.Headers.AddOrReplace(DefaultMessageHeaders.SourceEndpoint, envelope.Endpoint?.Name);
 
             _producer.Produce(
                 _transformationFunction?.Invoke(envelope.Message, exception) ?? envelope.Message ?? envelope.RawMessage,

--- a/src/Silverback.Integration/Messaging/ErrorHandling/RetryErrorPolicy.cs
+++ b/src/Silverback.Integration/Messaging/ErrorHandling/RetryErrorPolicy.cs
@@ -48,7 +48,7 @@ namespace Silverback.Messaging.ErrorHandling
         private void ApplyDelay(IReadOnlyCollection<IInboundEnvelope> envelopes)
         {
             var delay = _initialDelay.Milliseconds +
-                        envelopes.First().Headers.GetValueOrDefault<int>(MessageHeader.FailedAttemptsKey) *
+                        envelopes.First().Headers.GetValueOrDefault<int>(DefaultMessageHeaders.FailedAttempts) *
                         _delayIncrement.Milliseconds;
 
             if (delay <= 0)

--- a/src/Silverback.Integration/Messaging/LargeMessages/ChunkConsumer.cs
+++ b/src/Silverback.Integration/Messaging/LargeMessages/ChunkConsumer.cs
@@ -47,11 +47,11 @@ namespace Silverback.Messaging.LargeMessages
 
         private (string messageId, int chinkId, int chunksCount) ExtractHeadersValues(IInboundEnvelope envelope)
         {
-            var messageId = envelope.Headers.GetValue(MessageHeader.MessageIdKey);
+            var messageId = envelope.Headers.GetValue(DefaultMessageHeaders.MessageId);
 
-            var chunkId = envelope.Headers.GetValue<int>(MessageHeader.ChunkIdKey);
+            var chunkId = envelope.Headers.GetValue<int>(DefaultMessageHeaders.ChunkId);
 
-            var chunksCount = envelope.Headers.GetValue<int>(MessageHeader.ChunksCountKey);
+            var chunksCount = envelope.Headers.GetValue<int>(DefaultMessageHeaders.ChunksCount);
 
             if (string.IsNullOrEmpty(messageId))
                 throw new InvalidOperationException("Message id header not found or invalid.");

--- a/src/Silverback.Integration/Messaging/LargeMessages/ChunkProducer.cs
+++ b/src/Silverback.Integration/Messaging/LargeMessages/ChunkProducer.cs
@@ -11,7 +11,7 @@ namespace Silverback.Messaging.LargeMessages
     {
         public static IEnumerable<RawOutboundEnvelope> ChunkIfNeeded(RawOutboundEnvelope envelope)
         {
-            var messageId = envelope.Headers.GetValue(MessageHeader.MessageIdKey);
+            var messageId = envelope.Headers.GetValue(DefaultMessageHeaders.MessageId);
             var settings = envelope.Endpoint?.Chunk;
 
             var chunkSize = settings?.Size ?? int.MaxValue;
@@ -38,8 +38,8 @@ namespace Silverback.Messaging.LargeMessages
                 var slice = span.Slice(offset, Math.Min(chunkSize, envelope.RawMessage.Length - offset)).ToArray();
                 var messageChunk = new RawOutboundEnvelope(slice, envelope.Headers, envelope.Endpoint);
 
-                messageChunk.Headers.AddOrReplace(MessageHeader.ChunkIdKey, i);
-                messageChunk.Headers.AddOrReplace(MessageHeader.ChunksCountKey, chunksCount);
+                messageChunk.Headers.AddOrReplace(DefaultMessageHeaders.ChunkId, i);
+                messageChunk.Headers.AddOrReplace(DefaultMessageHeaders.ChunksCount, chunksCount);
 
                 yield return messageChunk;
 

--- a/src/Silverback.Integration/Messaging/Messages/DefaultMessageHeaders.cs
+++ b/src/Silverback.Integration/Messaging/Messages/DefaultMessageHeaders.cs
@@ -1,0 +1,82 @@
+// Copyright (c) 2020 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using Silverback.Messaging.Broker;
+using Silverback.Messaging.Serialization;
+
+namespace Silverback.Messaging.Messages
+{
+    public static class DefaultMessageHeaders
+    {
+        /// <summary>
+        ///     A unique identifier that may be useful for tracing. It may not be present if the produced message
+        ///     isn't implementing <c>IIntegrationMessage</c> and no <c>Id</c> or <c>MessageId</c> property of a
+        ///     supported type is defined.
+        /// </summary>
+        public const string MessageId = "x-message-id";
+
+        /// <summary>
+        ///     The assembly qualified name of the message type. Used by the default <see cref="JsonMessageSerializer" />.
+        /// </summary>
+        public const string MessageType = "x-message-type";
+
+        /// <summary>
+        ///     If an exception if thrown the failed attempts will be incremented and stored as header. This is
+        ///     necessary for the error policies to work.
+        /// </summary>
+        public const string FailedAttempts = "x-failed-attempts";
+
+        /// <summary>
+        ///     This will be set by the Move error policy and will contain the the name of the endpoint the failed
+        ///     message is being moved from.
+        /// </summary>
+        public const string SourceEndpoint = "x-source-endpoint";
+
+        /// <summary>
+        ///     The unique id of the message chunk, used when chunking is enabled.
+        /// </summary>
+        public const string ChunkId = "x-chunk-id";
+
+        /// <summary>
+        ///     The total number of chunks the message was split into, used when chunking is enabled.
+        /// </summary>
+        public const string ChunksCount = "x-chunks-count";
+
+        /// <summary>
+        ///     The unique id assigned to the messages batch, used mostly for tracing, when batch processing is enabled.
+        /// </summary>
+        public const string BatchId = "x-batch-id";
+
+        /// <summary>
+        ///     The total number of messages in the batch, used mostly for tracing, when batch processing is enabled.
+        /// </summary>
+        public const string BatchSize = "x-batch-size";
+
+        /// <summary>
+        ///     The current <c>Activity.Id</c>, used by the <see cref="IConsumer" /> implementation to set the
+        ///     <c>Activity.ParentId</c> and enabling distributed tracing across the message broker.
+        ///     Note that an <c>Activity</c> is automatically started by the default <see cref="IProducer" />
+        ///     implementation.
+        /// </summary>
+        /// <remarks>
+        ///     The header is implemented according to https://www.w3.org/TR/trace-context-1/#traceparent-header
+        /// </remarks>
+        public const string TraceId = "traceparent";
+
+        /// <summary>
+        ///     The <c>Activity.TraceStateString</c>.
+        /// </summary>
+        /// <remarks>
+        ///     The header is implemented according to https://www.w3.org/TR/trace-context-1/#traceparent-header
+        /// </remarks>
+        public const string TraceState = "tracestate";
+
+        /// <summary>
+        ///     The string representation of the <c>Activity.Baggage</c> dictionary.
+        /// </summary>
+        /// <remarks>
+        ///     This is not part of the w3c standard
+        /// </remarks>
+        public const string TraceBaggage = "tracebaggage";
+    }
+}

--- a/src/Silverback.Integration/Messaging/Messages/MessageHeader.cs
+++ b/src/Silverback.Integration/Messaging/Messages/MessageHeader.cs
@@ -10,15 +10,6 @@ namespace Silverback.Messaging.Messages
         private string _key;
         private string _value;
 
-        public const string MessageIdKey = "x-message-id";
-        public const string MessageTypeKey = "x-message-type";
-        public const string FailedAttemptsKey = "x-failed-attempts";
-        public const string ChunkIdKey = "x-chunk-id";
-        public const string ChunksCountKey = "x-chunks-count";
-        public const string BatchIdKey = "x-batch-id";
-        public const string BatchSizeKey = "x-batch-size";
-        public const string SourceEndpointKey = "x-source-endpoint";
-
         public MessageHeader()
         {
         }

--- a/src/Silverback.Integration/Messaging/Messages/MessageIdProvider.cs
+++ b/src/Silverback.Integration/Messaging/Messages/MessageIdProvider.cs
@@ -40,7 +40,7 @@ namespace Silverback.Messaging.Messages
             var key = _providers.FirstOrDefault(p =>
                 p.CanHandle(message))?.EnsureIdentifierIsInitialized(message);
 
-            headers.AddOrReplace(MessageHeader.MessageIdKey, key ?? Guid.NewGuid().ToString().ToLower());
+            headers.AddOrReplace(DefaultMessageHeaders.MessageId, key ?? Guid.NewGuid().ToString().ToLower());
         }
     }
 }

--- a/src/Silverback.Integration/Messaging/Messages/MessageLogger.cs
+++ b/src/Silverback.Integration/Messaging/Messages/MessageLogger.cs
@@ -95,21 +95,21 @@ namespace Silverback.Messaging.Messages
 
             properties.Add(("Endpoint", "endpointName", firstMessage.Endpoint?.Name));
 
-            var failedAttempts = firstMessage.Headers.GetValue<int>(MessageHeader.FailedAttemptsKey);
+            var failedAttempts = firstMessage.Headers.GetValue<int>(DefaultMessageHeaders.FailedAttempts);
             if (failedAttempts > 0)
                 properties.Add(("FailedAttempts", "failedAttempts", failedAttempts.ToString()));
 
             if (envelopes.Count == 1)
             {
-                properties.Add(("Type", "messageType", firstMessage.Headers.GetValue(MessageHeader.MessageTypeKey)));
-                properties.Add(("Id", "messageId", firstMessage.Headers.GetValue(MessageHeader.MessageIdKey)));
+                properties.Add(("Type", "messageType", firstMessage.Headers.GetValue(DefaultMessageHeaders.MessageType)));
+                properties.Add(("Id", "messageId", firstMessage.Headers.GetValue(DefaultMessageHeaders.MessageId)));
 
                 if (firstMessage.Offset != null)
                     properties.Add(("Offset", "offset", $"{firstMessage.Offset.Value}"));
             }
 
-            properties.Add(("BatchId", "batchId", firstMessage.Headers.GetValue(MessageHeader.BatchIdKey)));
-            properties.Add(("BatchSize", "batchSize", firstMessage.Headers.GetValue(MessageHeader.BatchSizeKey)));
+            properties.Add(("BatchId", "batchId", firstMessage.Headers.GetValue(DefaultMessageHeaders.BatchId)));
+            properties.Add(("BatchSize", "batchSize", firstMessage.Headers.GetValue(DefaultMessageHeaders.BatchSize)));
 
             // Don't log empty values
             properties.RemoveAll(x => string.IsNullOrWhiteSpace(x.Item3));

--- a/src/Silverback.Integration/Messaging/Serialization/JsonMessageSerializer.cs
+++ b/src/Silverback.Integration/Messaging/Serialization/JsonMessageSerializer.cs
@@ -37,7 +37,7 @@ namespace Silverback.Messaging.Serialization
             var type = message.GetType();
             var json = JsonConvert.SerializeObject(message, type, Settings);
 
-            messageHeaders.AddOrReplace(MessageHeader.MessageTypeKey, type.AssemblyQualifiedName);
+            messageHeaders.AddOrReplace(DefaultMessageHeaders.MessageType, type.AssemblyQualifiedName);
 
             return GetEncoding().GetBytes(json);
         }
@@ -50,7 +50,7 @@ namespace Silverback.Messaging.Serialization
                 return null;
             
             var json = GetEncoding().GetString(message);
-            var typeName = messageHeaders.GetValue(MessageHeader.MessageTypeKey);
+            var typeName = messageHeaders.GetValue(DefaultMessageHeaders.MessageType);
             var type = typeName != null ? Type.GetType(typeName) : typeof(object);
 
             return JsonConvert.DeserializeObject(json, type, Settings);

--- a/tests/Silverback.Integration.Configuration.Tests/Messaging/Configuration/ConfigurationReaderTests.cs
+++ b/tests/Silverback.Integration.Configuration.Tests/Messaging/Configuration/ConfigurationReaderTests.cs
@@ -228,11 +228,11 @@ namespace Silverback.Tests.Integration.Configuration.Messaging.Configuration
 
             var policy = reader.Inbound.First().ErrorPolicies.First();
             policy.CanHandle(
-                new InboundEnvelope(new byte[1], new[] { new MessageHeader(MessageHeader.FailedAttemptsKey, "3") },
+                new InboundEnvelope(new byte[1], new[] { new MessageHeader(DefaultMessageHeaders.FailedAttempts, "3") },
                     null,
                     new KafkaConsumerEndpoint("test")), new ArgumentException()).Should().BeTrue();
             policy.CanHandle(
-                new InboundEnvelope(new byte[1], new[] { new MessageHeader(MessageHeader.FailedAttemptsKey, "6") },
+                new InboundEnvelope(new byte[1], new[] { new MessageHeader(DefaultMessageHeaders.FailedAttempts, "6") },
                     null,
                     new KafkaConsumerEndpoint("test")), new ArgumentException()).Should().BeFalse();
         }

--- a/tests/Silverback.Integration.Tests/Messaging/Connectors/InboundConnectorTests.cs
+++ b/tests/Silverback.Integration.Tests/Messaging/Connectors/InboundConnectorTests.cs
@@ -138,11 +138,11 @@ namespace Silverback.Tests.Integration.Messaging.Connectors
             var consumer = _broker.Consumers.First();
             await consumer.TestPush(new TestEventOne { Id = Guid.NewGuid() });
             await consumer.TestPush(new TestEventOne { Id = Guid.NewGuid() },
-                new[] { new MessageHeader { Key = MessageHeader.FailedAttemptsKey, Value = "3" } });
+                new[] { new MessageHeader { Key = DefaultMessageHeaders.FailedAttempts, Value = "3" } });
 
             var inboundMessages = _inboundSubscriber.ReceivedEnvelopes.OfType<IInboundEnvelope>().ToList();
-            inboundMessages.First().Headers.GetValue<int>(MessageHeader.FailedAttemptsKey).Should().Be(null);
-            inboundMessages.Skip(1).First().Headers.GetValue<int>(MessageHeader.FailedAttemptsKey).Should().Be(3);
+            inboundMessages.First().Headers.GetValue<int>(DefaultMessageHeaders.FailedAttempts).Should().Be(null);
+            inboundMessages.Skip(1).First().Headers.GetValue<int>(DefaultMessageHeaders.FailedAttempts).Should().Be(3);
         }
 
         [Fact]
@@ -277,31 +277,31 @@ namespace Silverback.Tests.Integration.Messaging.Connectors
             var consumer = _broker.Consumers.First();
             await consumer.TestPush(buffer.Take(40).ToArray(), new[]
             {
-                new MessageHeader(MessageHeader.MessageIdKey, "123"),
-                new MessageHeader(MessageHeader.ChunkIdKey, "1"),
-                new MessageHeader(MessageHeader.ChunksCountKey, "4"),
-                new MessageHeader(MessageHeader.MessageTypeKey, typeof(TestEventOne).AssemblyQualifiedName)
+                new MessageHeader(DefaultMessageHeaders.MessageId, "123"),
+                new MessageHeader(DefaultMessageHeaders.ChunkId, "1"),
+                new MessageHeader(DefaultMessageHeaders.ChunksCount, "4"),
+                new MessageHeader(DefaultMessageHeaders.MessageType, typeof(TestEventOne).AssemblyQualifiedName)
             });
             await consumer.TestPush(buffer.Skip(40).Take(40).ToArray(), new[]
             {
-                new MessageHeader(MessageHeader.MessageIdKey, "123"),
-                new MessageHeader(MessageHeader.ChunkIdKey, "2"),
-                new MessageHeader(MessageHeader.ChunksCountKey, "4"),
-                new MessageHeader(MessageHeader.MessageTypeKey, typeof(TestEventOne).AssemblyQualifiedName)
+                new MessageHeader(DefaultMessageHeaders.MessageId, "123"),
+                new MessageHeader(DefaultMessageHeaders.ChunkId, "2"),
+                new MessageHeader(DefaultMessageHeaders.ChunksCount, "4"),
+                new MessageHeader(DefaultMessageHeaders.MessageType, typeof(TestEventOne).AssemblyQualifiedName)
             });
             await consumer.TestPush(buffer.Skip(80).Take(40).ToArray(), new[]
             {
-                new MessageHeader(MessageHeader.MessageIdKey, "123"),
-                new MessageHeader(MessageHeader.ChunkIdKey, "3"),
-                new MessageHeader(MessageHeader.ChunksCountKey, "4"),
-                new MessageHeader(MessageHeader.MessageTypeKey, typeof(TestEventOne).AssemblyQualifiedName)
+                new MessageHeader(DefaultMessageHeaders.MessageId, "123"),
+                new MessageHeader(DefaultMessageHeaders.ChunkId, "3"),
+                new MessageHeader(DefaultMessageHeaders.ChunksCount, "4"),
+                new MessageHeader(DefaultMessageHeaders.MessageType, typeof(TestEventOne).AssemblyQualifiedName)
             });
             await consumer.TestPush(buffer.Skip(120).ToArray(), new[]
             {
-                new MessageHeader(MessageHeader.MessageIdKey, "123"),
-                new MessageHeader(MessageHeader.ChunkIdKey, "4"),
-                new MessageHeader(MessageHeader.ChunksCountKey, "4"),
-                new MessageHeader(MessageHeader.MessageTypeKey, typeof(TestEventOne).AssemblyQualifiedName)
+                new MessageHeader(DefaultMessageHeaders.MessageId, "123"),
+                new MessageHeader(DefaultMessageHeaders.ChunkId, "4"),
+                new MessageHeader(DefaultMessageHeaders.ChunksCount, "4"),
+                new MessageHeader(DefaultMessageHeaders.MessageType, typeof(TestEventOne).AssemblyQualifiedName)
             });
 
             _testSubscriber.ReceivedMessages.Count.Should().Be(1);
@@ -320,31 +320,31 @@ namespace Silverback.Tests.Integration.Messaging.Connectors
             var consumer = _broker.Consumers.First();
             await consumer.TestPush(buffer.Take(40).ToArray(), new[]
             {
-                new MessageHeader(MessageHeader.MessageIdKey, "123"),
-                new MessageHeader(MessageHeader.ChunkIdKey, "1"),
-                new MessageHeader(MessageHeader.ChunksCountKey, "4"),
-                new MessageHeader(MessageHeader.MessageTypeKey, typeof(TestEventOne).AssemblyQualifiedName)
+                new MessageHeader(DefaultMessageHeaders.MessageId, "123"),
+                new MessageHeader(DefaultMessageHeaders.ChunkId, "1"),
+                new MessageHeader(DefaultMessageHeaders.ChunksCount, "4"),
+                new MessageHeader(DefaultMessageHeaders.MessageType, typeof(TestEventOne).AssemblyQualifiedName)
             });
             await consumer.TestPush(buffer.Skip(120).ToArray(), new[]
             {
-                new MessageHeader(MessageHeader.MessageIdKey, "123"),
-                new MessageHeader(MessageHeader.ChunkIdKey, "4"),
-                new MessageHeader(MessageHeader.ChunksCountKey, "4"),
-                new MessageHeader(MessageHeader.MessageTypeKey, typeof(TestEventOne).AssemblyQualifiedName)
+                new MessageHeader(DefaultMessageHeaders.MessageId, "123"),
+                new MessageHeader(DefaultMessageHeaders.ChunkId, "4"),
+                new MessageHeader(DefaultMessageHeaders.ChunksCount, "4"),
+                new MessageHeader(DefaultMessageHeaders.MessageType, typeof(TestEventOne).AssemblyQualifiedName)
             });
             await consumer.TestPush(buffer.Skip(80).Take(40).ToArray(), new[]
             {
-                new MessageHeader(MessageHeader.MessageIdKey, "123"),
-                new MessageHeader(MessageHeader.ChunkIdKey, "3"),
-                new MessageHeader(MessageHeader.ChunksCountKey, "4"),
-                new MessageHeader(MessageHeader.MessageTypeKey, typeof(TestEventOne).AssemblyQualifiedName)
+                new MessageHeader(DefaultMessageHeaders.MessageId, "123"),
+                new MessageHeader(DefaultMessageHeaders.ChunkId, "3"),
+                new MessageHeader(DefaultMessageHeaders.ChunksCount, "4"),
+                new MessageHeader(DefaultMessageHeaders.MessageType, typeof(TestEventOne).AssemblyQualifiedName)
             });
             await consumer.TestPush(buffer.Skip(40).Take(40).ToArray(), new[]
             {
-                new MessageHeader(MessageHeader.MessageIdKey, "123"),
-                new MessageHeader(MessageHeader.ChunkIdKey, "2"),
-                new MessageHeader(MessageHeader.ChunksCountKey, "4"),
-                new MessageHeader(MessageHeader.MessageTypeKey, typeof(TestEventOne).AssemblyQualifiedName)
+                new MessageHeader(DefaultMessageHeaders.MessageId, "123"),
+                new MessageHeader(DefaultMessageHeaders.ChunkId, "2"),
+                new MessageHeader(DefaultMessageHeaders.ChunksCount, "4"),
+                new MessageHeader(DefaultMessageHeaders.MessageType, typeof(TestEventOne).AssemblyQualifiedName)
             });
 
             _testSubscriber.ReceivedMessages.Count.Should().Be(1);
@@ -363,45 +363,45 @@ namespace Silverback.Tests.Integration.Messaging.Connectors
             var consumer = _broker.Consumers.First();
             await consumer.TestPush(buffer.Take(40).ToArray(), new[]
             {
-                new MessageHeader(MessageHeader.MessageIdKey, "123"),
-                new MessageHeader(MessageHeader.ChunkIdKey, "1"),
-                new MessageHeader(MessageHeader.ChunksCountKey, "4"),
-                new MessageHeader(MessageHeader.MessageTypeKey, typeof(TestEventOne).AssemblyQualifiedName)
+                new MessageHeader(DefaultMessageHeaders.MessageId, "123"),
+                new MessageHeader(DefaultMessageHeaders.ChunkId, "1"),
+                new MessageHeader(DefaultMessageHeaders.ChunksCount, "4"),
+                new MessageHeader(DefaultMessageHeaders.MessageType, typeof(TestEventOne).AssemblyQualifiedName)
             });
             await consumer.TestPush(buffer.Skip(120).ToArray(), new[]
             {
-                new MessageHeader(MessageHeader.MessageIdKey, "123"),
-                new MessageHeader(MessageHeader.ChunkIdKey, "4"),
-                new MessageHeader(MessageHeader.ChunksCountKey, "4"),
-                new MessageHeader(MessageHeader.MessageTypeKey, typeof(TestEventOne).AssemblyQualifiedName)
+                new MessageHeader(DefaultMessageHeaders.MessageId, "123"),
+                new MessageHeader(DefaultMessageHeaders.ChunkId, "4"),
+                new MessageHeader(DefaultMessageHeaders.ChunksCount, "4"),
+                new MessageHeader(DefaultMessageHeaders.MessageType, typeof(TestEventOne).AssemblyQualifiedName)
             });
             await consumer.TestPush(buffer.Skip(80).Take(40).ToArray(), new[]
             {
-                new MessageHeader(MessageHeader.MessageIdKey, "123"),
-                new MessageHeader(MessageHeader.ChunkIdKey, "3"),
-                new MessageHeader(MessageHeader.ChunksCountKey, "4"),
-                new MessageHeader(MessageHeader.MessageTypeKey, typeof(TestEventOne).AssemblyQualifiedName)
+                new MessageHeader(DefaultMessageHeaders.MessageId, "123"),
+                new MessageHeader(DefaultMessageHeaders.ChunkId, "3"),
+                new MessageHeader(DefaultMessageHeaders.ChunksCount, "4"),
+                new MessageHeader(DefaultMessageHeaders.MessageType, typeof(TestEventOne).AssemblyQualifiedName)
             });
             await consumer.TestPush(buffer.Skip(120).ToArray(), new[]
             {
-                new MessageHeader(MessageHeader.MessageIdKey, "123"),
-                new MessageHeader(MessageHeader.ChunkIdKey, "4"),
-                new MessageHeader(MessageHeader.ChunksCountKey, "4"),
-                new MessageHeader(MessageHeader.MessageTypeKey, typeof(TestEventOne).AssemblyQualifiedName)
+                new MessageHeader(DefaultMessageHeaders.MessageId, "123"),
+                new MessageHeader(DefaultMessageHeaders.ChunkId, "4"),
+                new MessageHeader(DefaultMessageHeaders.ChunksCount, "4"),
+                new MessageHeader(DefaultMessageHeaders.MessageType, typeof(TestEventOne).AssemblyQualifiedName)
             });
             await consumer.TestPush(buffer.Skip(80).Take(40).ToArray(), new[]
             {
-                new MessageHeader(MessageHeader.MessageIdKey, "123"),
-                new MessageHeader(MessageHeader.ChunkIdKey, "3"),
-                new MessageHeader(MessageHeader.ChunksCountKey, "4"),
-                new MessageHeader(MessageHeader.MessageTypeKey, typeof(TestEventOne).AssemblyQualifiedName)
+                new MessageHeader(DefaultMessageHeaders.MessageId, "123"),
+                new MessageHeader(DefaultMessageHeaders.ChunkId, "3"),
+                new MessageHeader(DefaultMessageHeaders.ChunksCount, "4"),
+                new MessageHeader(DefaultMessageHeaders.MessageType, typeof(TestEventOne).AssemblyQualifiedName)
             });
             await consumer.TestPush(buffer.Skip(40).Take(40).ToArray(), new[]
             {
-                new MessageHeader(MessageHeader.MessageIdKey, "123"),
-                new MessageHeader(MessageHeader.ChunkIdKey, "2"),
-                new MessageHeader(MessageHeader.ChunksCountKey, "4"),
-                new MessageHeader(MessageHeader.MessageTypeKey, typeof(TestEventOne).AssemblyQualifiedName)
+                new MessageHeader(DefaultMessageHeaders.MessageId, "123"),
+                new MessageHeader(DefaultMessageHeaders.ChunkId, "2"),
+                new MessageHeader(DefaultMessageHeaders.ChunksCount, "4"),
+                new MessageHeader(DefaultMessageHeaders.MessageType, typeof(TestEventOne).AssemblyQualifiedName)
             });
 
             _testSubscriber.ReceivedMessages.Count.Should().Be(1);
@@ -599,31 +599,31 @@ namespace Silverback.Tests.Integration.Messaging.Connectors
             var consumer = _broker.Consumers.First();
             await consumer.TestPush(buffer.Take(40).ToArray(), new[]
             {
-                new MessageHeader(MessageHeader.MessageIdKey, "123"),
-                new MessageHeader(MessageHeader.ChunkIdKey, "1"),
-                new MessageHeader(MessageHeader.ChunksCountKey, "4"),
-                new MessageHeader(MessageHeader.MessageTypeKey, typeof(TestEventOne).AssemblyQualifiedName)
+                new MessageHeader(DefaultMessageHeaders.MessageId, "123"),
+                new MessageHeader(DefaultMessageHeaders.ChunkId, "1"),
+                new MessageHeader(DefaultMessageHeaders.ChunksCount, "4"),
+                new MessageHeader(DefaultMessageHeaders.MessageType, typeof(TestEventOne).AssemblyQualifiedName)
             });
             await consumer.TestPush(buffer.Skip(40).Take(40).ToArray(), new[]
             {
-                new MessageHeader(MessageHeader.MessageIdKey, "123"),
-                new MessageHeader(MessageHeader.ChunkIdKey, "2"),
-                new MessageHeader(MessageHeader.ChunksCountKey, "4"),
-                new MessageHeader(MessageHeader.MessageTypeKey, typeof(TestEventOne).AssemblyQualifiedName)
+                new MessageHeader(DefaultMessageHeaders.MessageId, "123"),
+                new MessageHeader(DefaultMessageHeaders.ChunkId, "2"),
+                new MessageHeader(DefaultMessageHeaders.ChunksCount, "4"),
+                new MessageHeader(DefaultMessageHeaders.MessageType, typeof(TestEventOne).AssemblyQualifiedName)
             });
             await consumer.TestPush(buffer.Skip(80).Take(40).ToArray(), new[]
             {
-                new MessageHeader(MessageHeader.MessageIdKey, "123"),
-                new MessageHeader(MessageHeader.ChunkIdKey, "3"),
-                new MessageHeader(MessageHeader.ChunksCountKey, "4"),
-                new MessageHeader(MessageHeader.MessageTypeKey, typeof(TestEventOne).AssemblyQualifiedName)
+                new MessageHeader(DefaultMessageHeaders.MessageId, "123"),
+                new MessageHeader(DefaultMessageHeaders.ChunkId, "3"),
+                new MessageHeader(DefaultMessageHeaders.ChunksCount, "4"),
+                new MessageHeader(DefaultMessageHeaders.MessageType, typeof(TestEventOne).AssemblyQualifiedName)
             });
             await consumer.TestPush(buffer.Skip(120).ToArray(), new[]
             {
-                new MessageHeader(MessageHeader.MessageIdKey, "123"),
-                new MessageHeader(MessageHeader.ChunkIdKey, "4"),
-                new MessageHeader(MessageHeader.ChunksCountKey, "4"),
-                new MessageHeader(MessageHeader.MessageTypeKey, typeof(TestEventOne).AssemblyQualifiedName)
+                new MessageHeader(DefaultMessageHeaders.MessageId, "123"),
+                new MessageHeader(DefaultMessageHeaders.ChunkId, "4"),
+                new MessageHeader(DefaultMessageHeaders.ChunksCount, "4"),
+                new MessageHeader(DefaultMessageHeaders.MessageType, typeof(TestEventOne).AssemblyQualifiedName)
             });
 
             testSerializer.FailCount.Should().Be(3);
@@ -664,7 +664,7 @@ namespace Silverback.Tests.Integration.Messaging.Connectors
 
             var producer = (TestProducer) _broker.GetProducer(new TestProducerEndpoint("bad"));
 
-            producer.ProducedMessages.Last().Headers.Count(h => h.Key == MessageHeader.FailedAttemptsKey).Should()
+            producer.ProducedMessages.Last().Headers.Count(h => h.Key == DefaultMessageHeaders.FailedAttempts).Should()
                 .Be(1);
         }
 

--- a/tests/Silverback.Integration.Tests/Messaging/Diagnostics/ActivityConsumerBehaviorTests.cs
+++ b/tests/Silverback.Integration.Tests/Messaging/Diagnostics/ActivityConsumerBehaviorTests.cs
@@ -29,7 +29,7 @@ namespace Silverback.Tests.Integration.Messaging.Diagnostics
                 "123",
                 new MessageHeaderCollection
                 {
-                    { DiagnosticsConstants.TraceIdHeaderKey, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" }
+                    { DefaultMessageHeaders.TraceId, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" }
                 },
                 TestConsumerEndpoint.GetDefault());
 
@@ -55,7 +55,7 @@ namespace Silverback.Tests.Integration.Messaging.Diagnostics
                 "123",
                 new MessageHeaderCollection
                 {
-                    { DiagnosticsConstants.TraceIdHeaderKey, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" }
+                    { DefaultMessageHeaders.TraceId, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" }
                 },
                 TestConsumerEndpoint.GetDefault());
 
@@ -88,7 +88,7 @@ namespace Silverback.Tests.Integration.Messaging.Diagnostics
                 "123",
                 new MessageHeaderCollection
                 {
-                    { DiagnosticsConstants.TraceIdHeaderKey, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" }
+                    { DefaultMessageHeaders.TraceId, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" }
                 },
                 TestConsumerEndpoint.GetDefault());
 

--- a/tests/Silverback.Integration.Tests/Messaging/Diagnostics/ActivityExtensionsTests.cs
+++ b/tests/Silverback.Integration.Tests/Messaging/Diagnostics/ActivityExtensionsTests.cs
@@ -50,7 +50,7 @@ namespace Silverback.Tests.Integration.Messaging.Diagnostics
             activity.SetMessageHeaders(headers);
 
             headers.Should().ContainEquivalentOf(
-                new MessageHeader(DiagnosticsConstants.TraceIdHeaderKey, activity.Id));
+                new MessageHeader(DefaultMessageHeaders.TraceId, activity.Id));
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace Silverback.Tests.Integration.Messaging.Diagnostics
             activity.SetMessageHeaders(headers);
 
             headers.Should().ContainEquivalentOf(
-                new MessageHeader(DiagnosticsConstants.TraceStateHeaderKey, "Test"));
+                new MessageHeader(DefaultMessageHeaders.TraceState, "Test"));
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace Silverback.Tests.Integration.Messaging.Diagnostics
             activity.Start();
             activity.SetMessageHeaders(headers);
 
-            headers.Should().NotContain(h => h.Key == DiagnosticsConstants.TraceStateHeaderKey);
+            headers.Should().NotContain(h => h.Key == DefaultMessageHeaders.TraceState);
         }
 
         [Fact]
@@ -90,7 +90,7 @@ namespace Silverback.Tests.Integration.Messaging.Diagnostics
             activity.SetMessageHeaders(headers);
 
             headers.Should().ContainEquivalentOf(
-                new MessageHeader(DiagnosticsConstants.TraceBaggageHeaderKey, "key1=value1"));
+                new MessageHeader(DefaultMessageHeaders.TraceBaggage, "key1=value1"));
         }
 
         [Fact]
@@ -102,7 +102,7 @@ namespace Silverback.Tests.Integration.Messaging.Diagnostics
             activity.Start();
             activity.SetMessageHeaders(headers);
 
-            headers.Should().NotContain(h => h.Key == DiagnosticsConstants.TraceBaggageHeaderKey);
+            headers.Should().NotContain(h => h.Key == DefaultMessageHeaders.TraceBaggage);
         }
 
         [Fact]
@@ -120,7 +120,7 @@ namespace Silverback.Tests.Integration.Messaging.Diagnostics
         {
             var headers = new MessageHeaderCollection
             {
-                { DiagnosticsConstants.TraceIdHeaderKey, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" }
+                { DefaultMessageHeaders.TraceId, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" }
             };
 
             var activity = new Activity("test");
@@ -149,7 +149,7 @@ namespace Silverback.Tests.Integration.Messaging.Diagnostics
         {
             var headers = new MessageHeaderCollection
             {
-                { DiagnosticsConstants.TraceIdHeaderKey, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" }
+                { DefaultMessageHeaders.TraceId, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" }
             };
 
             var activity = new Activity("test");
@@ -165,8 +165,8 @@ namespace Silverback.Tests.Integration.Messaging.Diagnostics
         {
             var headers = new MessageHeaderCollection
             {
-                { DiagnosticsConstants.TraceIdHeaderKey, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" },
-                { DiagnosticsConstants.TraceBaggageHeaderKey, "key1=value1" }
+                { DefaultMessageHeaders.TraceId, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" },
+                { DefaultMessageHeaders.TraceBaggage, "key1=value1" }
             };
 
             var activity = new Activity("test");
@@ -181,8 +181,8 @@ namespace Silverback.Tests.Integration.Messaging.Diagnostics
         {
             var headers = new MessageHeaderCollection
             {
-                { DiagnosticsConstants.TraceIdHeaderKey, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" },
-                { DiagnosticsConstants.TraceStateHeaderKey, "key1=value1" }
+                { DefaultMessageHeaders.TraceId, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" },
+                { DefaultMessageHeaders.TraceState, "key1=value1" }
             };
 
             var activity = new Activity("test");

--- a/tests/Silverback.Integration.Tests/Messaging/Diagnostics/ActivityProducerBehaviorTests.cs
+++ b/tests/Silverback.Integration.Tests/Messaging/Diagnostics/ActivityProducerBehaviorTests.cs
@@ -34,7 +34,7 @@ namespace Silverback.Tests.Integration.Messaging.Diagnostics
             new ActivityProducerBehavior().Handle(rawEnvelope, _ => Task.CompletedTask);
 
             rawEnvelope.Headers.Should().Contain(
-                h => h.Key == DiagnosticsConstants.TraceIdHeaderKey &&
+                h => h.Key == DefaultMessageHeaders.TraceId &&
                      h.Value.StartsWith("00-0af7651916cd43dd8448eb211c80319c"));
         }
 
@@ -46,7 +46,7 @@ namespace Silverback.Tests.Integration.Messaging.Diagnostics
             new ActivityProducerBehavior().Handle(rawEnvelope, _ => Task.CompletedTask);
 
             rawEnvelope.Headers.Should().Contain(
-                h => h.Key == DiagnosticsConstants.TraceIdHeaderKey && !string.IsNullOrEmpty(h.Value));
+                h => h.Key == DefaultMessageHeaders.TraceId && !string.IsNullOrEmpty(h.Value));
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Silverback.Tests.Integration.Messaging.Diagnostics
             broker.GetProducer(TestProducerEndpoint.GetDefault()).Produce("123");
 
             broker.ProducedMessages.Single().Headers.Should().Contain(
-                h => h.Key == DiagnosticsConstants.TraceIdHeaderKey &&
+                h => h.Key == DefaultMessageHeaders.TraceId &&
                      h.Value.StartsWith("00-0af7651916cd43dd8448eb211c80319c"));
         }
 
@@ -89,7 +89,7 @@ namespace Silverback.Tests.Integration.Messaging.Diagnostics
             await broker.GetProducer(TestProducerEndpoint.GetDefault()).ProduceAsync("123");
 
             broker.ProducedMessages.Single().Headers.Should().Contain(
-                h => h.Key == DiagnosticsConstants.TraceIdHeaderKey &&
+                h => h.Key == DefaultMessageHeaders.TraceId &&
                      h.Value.StartsWith("00-0af7651916cd43dd8448eb211c80319c"));
         }
     }

--- a/tests/Silverback.Integration.Tests/Messaging/ErrorHandling/ErrorPolicyBaseTests.cs
+++ b/tests/Silverback.Integration.Tests/Messaging/ErrorHandling/ErrorPolicyBaseTests.cs
@@ -28,7 +28,7 @@ namespace Silverback.Tests.Integration.Messaging.ErrorHandling
             var canHandle = policy.CanHandle(
                 new InboundEnvelope(
                     new byte[1],
-                    new[] { new MessageHeader(MessageHeader.FailedAttemptsKey, "99") },
+                    new[] { new MessageHeader(DefaultMessageHeaders.FailedAttempts, "99") },
                     null, TestConsumerEndpoint.GetDefault()),
                 exception);
 
@@ -54,7 +54,7 @@ namespace Silverback.Tests.Integration.Messaging.ErrorHandling
             var canHandle = policy.CanHandle(
                 new InboundEnvelope(
                     new byte[1],
-                    new[] { new MessageHeader(MessageHeader.FailedAttemptsKey, "99") },
+                    new[] { new MessageHeader(DefaultMessageHeaders.FailedAttempts, "99") },
                     null, TestConsumerEndpoint.GetDefault()),
                 exception);
 
@@ -81,7 +81,7 @@ namespace Silverback.Tests.Integration.Messaging.ErrorHandling
             var canHandle = policy.CanHandle(
                 new InboundEnvelope(
                     new byte[1],
-                    new[] { new MessageHeader(MessageHeader.FailedAttemptsKey, "99") },
+                    new[] { new MessageHeader(DefaultMessageHeaders.FailedAttempts, "99") },
                     null, TestConsumerEndpoint.GetDefault()),
                 exception);
 
@@ -106,7 +106,7 @@ namespace Silverback.Tests.Integration.Messaging.ErrorHandling
         {
             var policy = (TestErrorPolicy) new TestErrorPolicy()
                 .ApplyWhen((msg, ex) =>
-                    msg.Headers.GetValue<int>(MessageHeader.FailedAttemptsKey) <= 5 && ex.Message != "no");
+                    msg.Headers.GetValue<int>(DefaultMessageHeaders.FailedAttempts) <= 5 && ex.Message != "no");
 
             var canHandle = policy.CanHandle(envelope, exception);
 
@@ -120,7 +120,7 @@ namespace Silverback.Tests.Integration.Messaging.ErrorHandling
                 {
                     new InboundEnvelope(
                         new byte[1],
-                        new[] { new MessageHeader(MessageHeader.FailedAttemptsKey, "3") },
+                        new[] { new MessageHeader(DefaultMessageHeaders.FailedAttempts, "3") },
                         null, TestConsumerEndpoint.GetDefault()),
                     new ArgumentException(),
                     true
@@ -129,7 +129,7 @@ namespace Silverback.Tests.Integration.Messaging.ErrorHandling
                 {
                     new InboundEnvelope(
                         new byte[1],
-                        new[] { new MessageHeader(MessageHeader.FailedAttemptsKey, "6") },
+                        new[] { new MessageHeader(DefaultMessageHeaders.FailedAttempts, "6") },
                         null, TestConsumerEndpoint.GetDefault()),
                     new ArgumentException(),
                     false
@@ -138,7 +138,7 @@ namespace Silverback.Tests.Integration.Messaging.ErrorHandling
                 {
                     new InboundEnvelope(
                         new byte[1],
-                        new[] { new MessageHeader(MessageHeader.FailedAttemptsKey, "3") },
+                        new[] { new MessageHeader(DefaultMessageHeaders.FailedAttempts, "3") },
                         null, TestConsumerEndpoint.GetDefault()),
                     new ArgumentException("no"),
                     false
@@ -156,7 +156,7 @@ namespace Silverback.Tests.Integration.Messaging.ErrorHandling
                     { Content = "aaa" });
             var message = new InboundEnvelope(
                 new byte[1],
-                new[] { new MessageHeader(MessageHeader.FailedAttemptsKey, "3") },
+                new[] { new MessageHeader(DefaultMessageHeaders.FailedAttempts, "3") },
                 null, TestConsumerEndpoint.GetDefault());
 
 

--- a/tests/Silverback.Integration.Tests/Messaging/ErrorHandling/ErrorPolicyChainTests.cs
+++ b/tests/Silverback.Integration.Tests/Messaging/ErrorHandling/ErrorPolicyChainTests.cs
@@ -51,7 +51,7 @@ namespace Silverback.Tests.Integration.Messaging.ErrorHandling
             {
                 new InboundEnvelope(
                     new byte[1],
-                    new[] { new MessageHeader(MessageHeader.FailedAttemptsKey, failedAttempts.ToString()) },
+                    new[] { new MessageHeader(DefaultMessageHeaders.FailedAttempts, failedAttempts.ToString()) },
                     null, TestConsumerEndpoint.GetDefault())
             }, new Exception("test"));
 
@@ -73,7 +73,7 @@ namespace Silverback.Tests.Integration.Messaging.ErrorHandling
             {
                 new InboundEnvelope(
                     new byte[1],
-                    new[] { new MessageHeader(MessageHeader.FailedAttemptsKey, failedAttempts.ToString()) },
+                    new[] { new MessageHeader(DefaultMessageHeaders.FailedAttempts, failedAttempts.ToString()) },
                     null, TestConsumerEndpoint.GetDefault())
             }, new Exception("test"));
 
@@ -103,7 +103,7 @@ namespace Silverback.Tests.Integration.Messaging.ErrorHandling
             {
                 new InboundEnvelope(
                     new byte[1],
-                    new[] { new MessageHeader(MessageHeader.FailedAttemptsKey, failedAttempts.ToString()) },
+                    new[] { new MessageHeader(DefaultMessageHeaders.FailedAttempts, failedAttempts.ToString()) },
                     null, TestConsumerEndpoint.GetDefault())
             }, new Exception("test"));
 

--- a/tests/Silverback.Integration.Tests/Messaging/ErrorHandling/MoveMessageErrorPolicyTests.cs
+++ b/tests/Silverback.Integration.Tests/Messaging/ErrorHandling/MoveMessageErrorPolicyTests.cs
@@ -147,7 +147,7 @@ namespace Silverback.Tests.Integration.Messaging.ErrorHandling
             {
                 new InboundEnvelope(
                     Encoding.UTF8.GetBytes("hey oh!"),
-                    new[] { new MessageHeader(MessageHeader.MessageTypeKey, typeof(string).AssemblyQualifiedName) },
+                    new[] { new MessageHeader(DefaultMessageHeaders.MessageType, typeof(string).AssemblyQualifiedName) },
                     null, TestConsumerEndpoint.GetDefault()),
             }, new Exception("test"));
 
@@ -203,7 +203,7 @@ namespace Silverback.Tests.Integration.Messaging.ErrorHandling
             producer.ProducedMessages.Last()
                 .Headers
                 .Should().ContainEquivalentOf(new MessageHeader(
-                    MessageHeader.SourceEndpointKey,
+                    DefaultMessageHeaders.SourceEndpoint,
                     "source-endpoint"));
         }
     }

--- a/tests/Silverback.Integration.Tests/Messaging/ErrorHandling/RetryErrorPolicyTests.cs
+++ b/tests/Silverback.Integration.Tests/Messaging/ErrorHandling/RetryErrorPolicyTests.cs
@@ -50,7 +50,7 @@ namespace Silverback.Tests.Integration.Messaging.ErrorHandling
             {
                 new InboundEnvelope(
                     new byte[1],
-                    new[] { new MessageHeader(MessageHeader.FailedAttemptsKey, failedAttempts.ToString()) },
+                    new[] { new MessageHeader(DefaultMessageHeaders.FailedAttempts, failedAttempts.ToString()) },
                     null, TestConsumerEndpoint.GetDefault()),
             }, new Exception("test"));
 

--- a/tests/Silverback.Integration.Tests/Messaging/ErrorHandling/SkipMessageErrorPolicyTests.cs
+++ b/tests/Silverback.Integration.Tests/Messaging/ErrorHandling/SkipMessageErrorPolicyTests.cs
@@ -29,7 +29,7 @@ namespace Silverback.Tests.Integration.Messaging.ErrorHandling
             {
                 new InboundEnvelope(
                     new byte[1],
-                    new[] { new MessageHeader(MessageHeader.FailedAttemptsKey, failedAttempts.ToString()) },
+                    new[] { new MessageHeader(DefaultMessageHeaders.FailedAttempts, failedAttempts.ToString()) },
                     null, TestConsumerEndpoint.GetDefault()),
             }, new Exception("test"));
 

--- a/tests/Silverback.Integration.Tests/Messaging/LargeMessages/ChunkConsumerTests.cs
+++ b/tests/Silverback.Integration.Tests/Messaging/LargeMessages/ChunkConsumerTests.cs
@@ -36,27 +36,27 @@ namespace Silverback.Tests.Integration.Messaging.LargeMessages
                 originalSerializedMessage.AsMemory().Slice(0, 300).ToArray(),
                 new[]
                 {
-                    new MessageHeader(MessageHeader.MessageIdKey, originalMessage.MessageId.ToString()),
-                    new MessageHeader(MessageHeader.ChunkIdKey, "0"),
-                    new MessageHeader(MessageHeader.ChunksCountKey, "3"),
+                    new MessageHeader(DefaultMessageHeaders.MessageId, originalMessage.MessageId.ToString()),
+                    new MessageHeader(DefaultMessageHeaders.ChunkId, "0"),
+                    new MessageHeader(DefaultMessageHeaders.ChunksCount, "3"),
                 },
                 null, TestConsumerEndpoint.GetDefault());
             chunks[1] = new InboundEnvelope(
                 originalSerializedMessage.AsMemory().Slice(300, 300).ToArray(),
                 new[]
                 {
-                    new MessageHeader(MessageHeader.MessageIdKey, originalMessage.MessageId.ToString()),
-                    new MessageHeader(MessageHeader.ChunkIdKey, "1"),
-                    new MessageHeader(MessageHeader.ChunksCountKey, "3"),
+                    new MessageHeader(DefaultMessageHeaders.MessageId, originalMessage.MessageId.ToString()),
+                    new MessageHeader(DefaultMessageHeaders.ChunkId, "1"),
+                    new MessageHeader(DefaultMessageHeaders.ChunksCount, "3"),
                 },
                 null, TestConsumerEndpoint.GetDefault());
             chunks[2] = new InboundEnvelope(
                 originalSerializedMessage.AsMemory().Slice(600).ToArray(),
                 new[]
                 {
-                    new MessageHeader(MessageHeader.MessageIdKey, originalMessage.MessageId.ToString()),
-                    new MessageHeader(MessageHeader.ChunkIdKey, "2"),
-                    new MessageHeader(MessageHeader.ChunksCountKey, "3"),
+                    new MessageHeader(DefaultMessageHeaders.MessageId, originalMessage.MessageId.ToString()),
+                    new MessageHeader(DefaultMessageHeaders.ChunkId, "2"),
+                    new MessageHeader(DefaultMessageHeaders.ChunksCount, "3"),
                 },
                 null, TestConsumerEndpoint.GetDefault());
 

--- a/tests/Silverback.Integration.Tests/Messaging/LargeMessages/ChunkProducerTests.cs
+++ b/tests/Silverback.Integration.Tests/Messaging/LargeMessages/ChunkProducerTests.cs
@@ -56,7 +56,7 @@ namespace Silverback.Tests.Integration.Messaging.LargeMessages
             };
             var headers = new MessageHeaderCollection
             {
-                { MessageHeader.MessageIdKey, "1234" }
+                { DefaultMessageHeaders.MessageId, "1234" }
             };
 
             var serializedMessage = _serializer.Serialize(message, headers);


### PR DESCRIPTION
This is related to the issue #60.
What I do here is instead of relying on the header, I properly read the Kafka key from the client library and I set the header in the consumer.