### PR TITLE
Topic/perf test for logger extensions

### DIFF
--- a/src/Silverback.Integration/Properties/AssemblyInfo.cs
+++ b/src/Silverback.Integration/Properties/AssemblyInfo.cs
@@ -7,3 +7,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Silverback.Integration.Configuration.Tests")]
 [assembly: InternalsVisibleTo("Silverback.Integration.Kafka.Tests")]
 [assembly: InternalsVisibleTo("Silverback.Integration.RabbitMQ.Tests")]
+[assembly: InternalsVisibleTo("Silverback.Tests.Performance")]

--- a/tests/Silverback.Tests.Performance/LoggerExtensionsBenchmark.cs
+++ b/tests/Silverback.Tests.Performance/LoggerExtensionsBenchmark.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Logging;
+using Silverback.Messaging.Messages;
+using Silverback.Tests.Integration.TestTypes;
+using LoggerExtensions = Silverback.Messaging.Messages.LoggerExtensions;
+using NullLogger = Microsoft.Extensions.Logging.Abstractions.NullLogger;
+
+namespace Silverback.Tests.Performance
+{
+    // Starting point
+    // | Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+    // |------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
+    // |    Log | 2.629 us | 0.0502 us | 0.0493 us | 0.6371 |     - |     - |   2.62 KB |
+    [MemoryDiagnoser]
+    public class LoggerExtensionsBenchmark
+    {
+        private readonly List<IRawBrokerEnvelope> _rawBrokerEnvelopes = new List<IRawBrokerEnvelope>
+        {
+            new RawInboundEnvelope(
+                Array.Empty<byte>(),
+                new List<MessageHeader>
+                {
+                    new MessageHeader("Test", "Test"),
+                    new MessageHeader(DefaultMessageHeaders.FailedAttempts, 1),
+                    new MessageHeader(DefaultMessageHeaders.MessageType, "Something.Xy"),
+                    new MessageHeader(DefaultMessageHeaders.MessageId, "1234"),
+                    new MessageHeader(DefaultMessageHeaders.BatchId, "1234"),
+                    new MessageHeader(DefaultMessageHeaders.BatchSize, "11"),
+                },
+                new TestConsumerEndpoint("Test"),
+                "Test",
+                new TestOffset("abc", "1"))
+        };
+
+        [Benchmark]
+        public void Log()
+        {
+            LoggerExtensions.Log(
+                NullLogger.Instance,
+                LogLevel.Error,
+                new EventId(1, "Something"),
+                null,
+                "This is my log message",
+                _rawBrokerEnvelopes);
+        }
+    }
+}


### PR DESCRIPTION
Due to our discussion about logging, I realized that the Log-Method allocates like there is no memory limit ;)

Could maybe changed by using a Logger Scope or smth like this. I did not have time to start tuning but added the perf test.