### PR TITLE
Make it clear that you need to call SaveChangesAsync on DBContext for the messages to be actually published

### DIFF
--- a/docs/concepts/broker/outbound.md
+++ b/docs/concepts/broker/outbound.md
@@ -235,6 +235,24 @@ public class MyEndpointsConfigurator : IEndpointsConfigurator
                 });
 }
 ```
+# [Publisher](#tab/publisher)
+```csharp
+private readonly IPublisher _publisher;
+private readonly SampleDbContext _dbContext;
+
+public async Task CancelOrder(int orderId)
+{
+    // You can change database here
+    
+    await _publisher.PublishAsync(new OrderCancelledEvent
+    {
+        OrderId = orderId
+    });
+
+	// No messages will be published unless you call SaveChangesAsync!
+    await _dbContext.SaveChangesAsync();
+}
+```
 ***
 
 ### Custom outbox

--- a/docs/concepts/broker/outbound.md
+++ b/docs/concepts/broker/outbound.md
@@ -249,7 +249,7 @@ public async Task CancelOrder(int orderId)
         OrderId = orderId
     });
 
-	// No messages will be published unless you call SaveChangesAsync!
+    // No messages will be published unless you call SaveChangesAsync!
     await _dbContext.SaveChangesAsync();
 }
 ```

--- a/docs/concepts/broker/outbound.md
+++ b/docs/concepts/broker/outbound.md
@@ -242,7 +242,7 @@ private readonly SampleDbContext _dbContext;
 
 public async Task CancelOrder(int orderId)
 {
-    // You can change database here
+    // You can use _dbContext to update/insert entities here
     
     await _publisher.PublishAsync(new OrderCancelledEvent
     {


### PR DESCRIPTION
Although in hindsight it makes sense that it works that way, but I wasted many hours debugging why messages were not being published to the outbox thinking that I had configured it incorrectly. Since I was just trying out Silverback, I had no entities to change and had written this code:

```csharp
[HttpGet]
public async Task PublishEcho(string text)
{
    await _publisher.PublishAsync(new EchoMessage
    {
        Text = text
    });

    _logger.LogInformation($"Produced: Echo => {text}");
}
```

I have added a code snippet to make it clear you need to call  SaveChangesAsync on DBContext for the messages to be actually published.