### PR TITLE
feat: implement custom headers for failed messages

### DIFF
--- a/src/Silverback.Integration.Kafka/Messaging/Configuration/ErrorPolicyChainBuilderMoveToKafkaTopicExtensions.cs
+++ b/src/Silverback.Integration.Kafka/Messaging/Configuration/ErrorPolicyChainBuilderMoveToKafkaTopicExtensions.cs
@@ -39,7 +39,8 @@ namespace Silverback.Messaging.Configuration
             Check.NotNull(endpointBuilderAction, nameof(endpointBuilderAction));
 
             var kafkaClientConfig =
-                ((builder as ErrorPolicyChainBuilder)?.EndpointsConfigurationBuilder as KafkaEndpointsConfigurationBuilder)
+                ((builder as ErrorPolicyChainBuilder)?.EndpointsConfigurationBuilder as
+                    KafkaEndpointsConfigurationBuilder)
                 ?.ClientConfig;
 
             var endpointBuilder = new KafkaProducerEndpointBuilder(kafkaClientConfig);

--- a/src/Silverback.Integration.Kafka/Messaging/Configuration/KafkaBrokerHeadersEnricher.cs
+++ b/src/Silverback.Integration.Kafka/Messaging/Configuration/KafkaBrokerHeadersEnricher.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2020 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System;
+using Silverback.Messaging.Broker;
+using Silverback.Messaging.Messages;
+using Silverback.Messaging.Outbound.Enrichers;
+
+namespace Silverback.Messaging.Configuration
+{
+    internal sealed class KafkaBrokerHeadersEnricher
+        : IMovePolicyMessageEnricher<KafkaProducerEndpoint>, IMovePolicyMessageEnricher<KafkaConsumerEndpoint>
+    {
+        public void Enrich(
+            IRawInboundEnvelope inboundEnvelope,
+            IOutboundEnvelope outboundEnvelope,
+            Exception exception)
+        {
+            outboundEnvelope.Headers.AddOrReplace(
+                KafkaMessageHeaders.SourceTopic,
+                inboundEnvelope.ActualEndpointName);
+            outboundEnvelope.Headers.AddOrReplace(
+                KafkaMessageHeaders.SourceConsumerGroupId,
+                ((KafkaConsumerEndpoint)inboundEnvelope.Endpoint).Configuration.GroupId);
+            outboundEnvelope.Headers.AddOrReplace(
+                DefaultMessageHeaders.FailureReason,
+                $"{exception.GetType().FullName} in {exception.Source}");
+            outboundEnvelope.Headers.AddOrReplace(
+                KafkaMessageHeaders.SourcePartition,
+                ((KafkaOffset)inboundEnvelope.BrokerMessageIdentifier).Partition);
+            outboundEnvelope.Headers.AddOrReplace(
+                KafkaMessageHeaders.SourceOffset,
+                ((KafkaOffset)inboundEnvelope.BrokerMessageIdentifier).Offset);
+
+            if (inboundEnvelope.Headers.Contains(KafkaMessageHeaders.TimestampKey))
+            {
+                outboundEnvelope.Headers.AddOrReplace(
+                    KafkaMessageHeaders.SourceTimestamp,
+                    inboundEnvelope.Headers[KafkaMessageHeaders.TimestampKey]);
+            }
+        }
+    }
+}

--- a/src/Silverback.Integration.Kafka/Messaging/Configuration/KafkaBrokerOptionsConfigurator.cs
+++ b/src/Silverback.Integration.Kafka/Messaging/Configuration/KafkaBrokerOptionsConfigurator.cs
@@ -7,6 +7,7 @@ using Silverback.Messaging.Broker;
 using Silverback.Messaging.Broker.Kafka;
 using Silverback.Messaging.Diagnostics;
 using Silverback.Messaging.Outbound;
+using Silverback.Messaging.Outbound.Enrichers;
 using Silverback.Messaging.Outbound.Routing;
 using Silverback.Util;
 
@@ -35,7 +36,11 @@ namespace Silverback.Messaging.Configuration
                 .AddSingleton<IBrokerLogEnricher<KafkaProducerEndpoint>, KafkaLogEnricher>()
                 .AddSingleton<IBrokerLogEnricher<KafkaConsumerEndpoint>, KafkaLogEnricher>()
                 .AddSingleton<IBrokerActivityEnricher<KafkaProducerEndpoint>, KafkaActivityEnricher>()
-                .AddSingleton<IBrokerActivityEnricher<KafkaConsumerEndpoint>, KafkaActivityEnricher>();
+                .AddSingleton<IBrokerActivityEnricher<KafkaConsumerEndpoint>, KafkaActivityEnricher>()
+                .AddSingleton<IMovePolicyMessageEnricher<KafkaProducerEndpoint>,
+                    KafkaBrokerHeadersEnricher>()
+                .AddSingleton<IMovePolicyMessageEnricher<KafkaConsumerEndpoint>,
+                    KafkaBrokerHeadersEnricher>();
         }
     }
 }

--- a/src/Silverback.Integration.Kafka/Messaging/Messages/KafkaMessageHeaders.cs
+++ b/src/Silverback.Integration.Kafka/Messaging/Messages/KafkaMessageHeaders.cs
@@ -22,6 +22,36 @@ namespace Silverback.Messaging.Messages
         /// <summary>
         ///     The header that will be filled with the timestamp of the message consumed from Kafka.
         /// </summary>
-        public const string TimestampKey = "x-kafka-message-timestamp";
+        public const string TimestampKey = "x-message-timestamp";
+
+        /// <summary>
+        ///     This will be set by the Move error policy and will contain the group ID of the consumer who processed the
+        ///     failed message.
+        /// </summary>
+        public const string SourceConsumerGroupId = "x-source-consumer-group-id";
+
+        /// <summary>
+        ///     This will be set by the Move error policy and will contain the topic of the failed
+        ///     message.
+        /// </summary>
+        public const string SourceTopic = "x-source-topic";
+
+        /// <summary>
+        ///     This will be set by the Move error policy and will contain the partition of the failed
+        ///     message.
+        /// </summary>
+        public const string SourcePartition = "x-source-partition";
+
+        /// <summary>
+        ///     This will be set by the Move error policy and will contain the offset of the failed
+        ///     message.
+        /// </summary>
+        public const string SourceOffset = "x-source-offset";
+
+        /// <summary>
+        ///     This will be set by the Move error policy and will contain the timestamp of the failed
+        ///     message.
+        /// </summary>
+        public const string SourceTimestamp = "x-source-timestamp";
     }
 }

--- a/src/Silverback.Integration/Messaging/Configuration/SilverbackBuilderWithConnectionToExtensions.cs
+++ b/src/Silverback.Integration/Messaging/Configuration/SilverbackBuilderWithConnectionToExtensions.cs
@@ -7,6 +7,7 @@ using Silverback.Messaging.Broker;
 using Silverback.Messaging.Broker.Callbacks;
 using Silverback.Messaging.Configuration;
 using Silverback.Messaging.Diagnostics;
+using Silverback.Messaging.Outbound.Enrichers;
 using Silverback.Messaging.Outbound.Routing;
 using Silverback.Util;
 
@@ -55,7 +56,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddSingleton(typeof(IOutboundLogger<>), typeof(OutboundLogger<>))
                 .AddSingleton<InboundLoggerFactory>()
                 .AddSingleton<OutboundLoggerFactory>()
-                .AddSingleton<BrokerLogEnricherFactory>();
+                .AddSingleton<BrokerLogEnricherFactory>()
+                .AddSingleton<IBrokerOutboundMessageEnrichersFactory, BrokerOutboundMessageEnrichersFactory>();
 
             // Activities
             silverbackBuilder.Services.AddSingleton<IActivityEnricherFactory, ActivityEnricherFactory>();

--- a/src/Silverback.Integration/Messaging/Inbound/ErrorHandling/ErrorPoliciesHelper.cs
+++ b/src/Silverback.Integration/Messaging/Inbound/ErrorHandling/ErrorPoliciesHelper.cs
@@ -10,13 +10,16 @@ namespace Silverback.Messaging.Inbound.ErrorHandling
 {
     internal static class ErrorPoliciesHelper
     {
-        public static async Task<bool> ApplyErrorPoliciesAsync(ConsumerPipelineContext context, Exception exception)
+        public static async Task<bool> ApplyErrorPoliciesAsync(
+            ConsumerPipelineContext context,
+            Exception exception)
         {
-            var failedAttempts = context.Consumer.IncrementFailedAttempts(context.Envelope);
+            int failedAttempts = context.Consumer.IncrementFailedAttempts(context.Envelope);
 
             context.Envelope.Headers.AddOrReplace(DefaultMessageHeaders.FailedAttempts, failedAttempts);
 
-            var errorPolicyImplementation = context.Envelope.Endpoint.ErrorPolicy.Build(context.ServiceProvider);
+            IErrorPolicyImplementation errorPolicyImplementation =
+                context.Envelope.Endpoint.ErrorPolicy.Build(context.ServiceProvider);
 
             if (!errorPolicyImplementation.CanHandle(context, exception))
                 return false;

--- a/src/Silverback.Integration/Messaging/Messages/DefaultMessageHeaders.cs
+++ b/src/Silverback.Integration/Messaging/Messages/DefaultMessageHeaders.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2020 Sergio Aquilini
 // This code is licensed under MIT license (see LICENSE file for details)
 
+using System;
 using Silverback.Messaging.Broker;
 using Silverback.Messaging.Serialization;
 
@@ -99,5 +100,18 @@ namespace Silverback.Messaging.Messages
         ///     consumer side to determine the correct key to be used to decrypt the message.
         /// </remarks>
         public const string EncryptionKeyId = "x-encryption-key-id";
+
+        /// <summary>
+        ///     This will be set by the Move error policy and will contain the reason the failed
+        ///     message is being moved.
+        /// </summary>
+        public const string FailureReason = "x-failure-reason";
+
+        /// <summary>
+        ///     This will be set by the Move error policy and will contain the timestamp of the failed
+        ///     message.
+        /// </summary>
+        [Obsolete("Replaced by KafkaMessageHeaders.SourceTimestamp.")]
+        public const string SourceTimestamp = "x-source-timestamp";
     }
 }

--- a/src/Silverback.Integration/Messaging/Outbound/Enrichers/BrokerOutboundMessageEnrichersFactory.cs
+++ b/src/Silverback.Integration/Messaging/Outbound/Enrichers/BrokerOutboundMessageEnrichersFactory.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) 2020 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Silverback.Messaging.Messages;
+
+namespace Silverback.Messaging.Outbound.Enrichers
+{
+    internal sealed class BrokerOutboundMessageEnrichersFactory : IBrokerOutboundMessageEnrichersFactory
+    {
+        private static readonly NullEnricher NullEnricherInstance = new();
+
+        private readonly IServiceProvider _serviceProvider;
+
+        private readonly ConcurrentDictionary<Type, Type> _enricherTypeCache = new();
+
+        public BrokerOutboundMessageEnrichersFactory(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public IEnumerable<IMovePolicyMessageEnricher> GetMovePolicyEnrichers(IEndpoint endpoint)
+        {
+            var enricherType = _enricherTypeCache.GetOrAdd(
+                endpoint.GetType(),
+                type => typeof(IMovePolicyMessageEnricher<>)
+                    .MakeGenericType(type));
+
+            var headersEnricher = (IMovePolicyMessageEnricher?)_serviceProvider.GetService(enricherType);
+
+            yield return headersEnricher ?? NullEnricherInstance;
+        }
+
+        private sealed class NullEnricher : IMovePolicyMessageEnricher
+        {
+            public void Enrich(IRawInboundEnvelope inboundEnvelope, IOutboundEnvelope outboundEnvelope, Exception exception)
+            {
+            }
+        }
+    }
+}

--- a/src/Silverback.Integration/Messaging/Outbound/Enrichers/IBrokerOutboundMessageEnrichersFactory.cs
+++ b/src/Silverback.Integration/Messaging/Outbound/Enrichers/IBrokerOutboundMessageEnrichersFactory.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) 2020 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System.Collections.Generic;
+
+namespace Silverback.Messaging.Outbound.Enrichers
+{
+    /// <summary>
+    ///     Provides the list of <see cref="IMovePolicyMessageEnricher" /> according to the specified endpoint.
+    /// </summary>
+    public interface IBrokerOutboundMessageEnrichersFactory
+    {
+        /// <summary>
+        ///     Returns the list of <see cref="IMovePolicyMessageEnricher" /> for the specified endpoint.
+        /// </summary>
+        /// <param name="endpoint">
+        ///     The endpoint.
+        /// </param>
+        /// <returns>
+        ///     The list of <see cref="IMovePolicyMessageEnricher" /> that matches the specified endpoint type.
+        /// </returns>
+        IEnumerable<IMovePolicyMessageEnricher> GetMovePolicyEnrichers(IEndpoint endpoint);
+    }
+}

--- a/src/Silverback.Integration/Messaging/Outbound/Enrichers/IMovePolicyMessageEnricher.cs
+++ b/src/Silverback.Integration/Messaging/Outbound/Enrichers/IMovePolicyMessageEnricher.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) 2020 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System;
+using Silverback.Messaging.Messages;
+
+namespace Silverback.Messaging.Outbound.Enrichers
+{
+    /// <summary>
+    ///     Enriches the outbound message being moved.
+    /// </summary>
+    public interface IMovePolicyMessageEnricher
+    {
+        /// <summary>
+        ///     Enriches the specified message.
+        /// </summary>
+        /// <param name="inboundEnvelope">
+        ///     The envelope containing the message which failed to be processed.
+        /// </param>
+        /// <param name="outboundEnvelope">
+        ///     The envelope containing the message to be enriched.
+        /// </param>
+        /// <param name="exception">
+        ///     The exception thrown during the message processing.
+        /// </param>
+        void Enrich(
+            IRawInboundEnvelope inboundEnvelope,
+            IOutboundEnvelope outboundEnvelope,
+            Exception exception);
+    }
+}

--- a/src/Silverback.Integration/Messaging/Outbound/Enrichers/IMovePolicyMessageEnricher`1.cs
+++ b/src/Silverback.Integration/Messaging/Outbound/Enrichers/IMovePolicyMessageEnricher`1.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) 2020 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Silverback.Messaging.Outbound.Enrichers
+{
+    /// <summary>
+    ///     Enriches the outbound message being moved.
+    /// </summary>
+    /// <typeparam name="TEndpoint">
+    ///     The type of the endpoint that this enricher can be used for.
+    /// </typeparam>
+    [SuppressMessage("ReSharper", "UnusedTypeParameter", Justification = "Used for DI")]
+    public interface IMovePolicyMessageEnricher<TEndpoint> : IMovePolicyMessageEnricher
+        where TEndpoint : Endpoint
+    {
+    }
+}

--- a/tests/Silverback.Integration.Tests.E2E/Kafka/ErrorHandlingTests.cs
+++ b/tests/Silverback.Integration.Tests.E2E/Kafka/ErrorHandlingTests.cs
@@ -55,14 +55,22 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                         .WithConnectionToMessageBroker(options => options.AddMockedKafka())
                         .AddKafkaEndpoints(
                             endpoints => endpoints
-                                .Configure(config => { config.BootstrapServers = "PLAINTEXT://e2e"; })
+                                .Configure(
+                                    config =>
+                                    {
+                                        config.BootstrapServers = "PLAINTEXT://e2e";
+                                    })
                                 .AddOutbound<IIntegrationEvent>(
                                     endpoint => endpoint.ProduceTo(DefaultTopicName))
                                 .AddInbound(
                                     endpoint => endpoint
                                         .ConsumeFrom(DefaultTopicName)
                                         .OnError(policy => policy.Retry(10))
-                                        .Configure(config => { config.GroupId = "consumer1"; })))
+                                        .Configure(
+                                            config =>
+                                            {
+                                                config.GroupId = "consumer1";
+                                            })))
                         .AddIntegrationSpy()
                         .AddDelegateSubscriber(
                             (IIntegrationEvent _) =>
@@ -97,7 +105,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                         .WithConnectionToMessageBroker(options => options.AddMockedKafka())
                         .AddKafkaEndpoints(
                             endpoints => endpoints
-                                .Configure(config => { config.BootstrapServers = "PLAINTEXT://e2e"; })
+                                .Configure(
+                                    config =>
+                                    {
+                                        config.BootstrapServers = "PLAINTEXT://e2e";
+                                    })
                                 .AddOutbound<IIntegrationEvent>(
                                     endpoint => endpoint.ProduceTo(DefaultTopicName))
                                 .AddInbound(
@@ -147,7 +159,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                         .WithConnectionToMessageBroker(options => options.AddMockedKafka())
                         .AddKafkaEndpoints(
                             endpoints => endpoints
-                                .Configure(config => { config.BootstrapServers = "PLAINTEXT://e2e"; })
+                                .Configure(
+                                    config =>
+                                    {
+                                        config.BootstrapServers = "PLAINTEXT://e2e";
+                                    })
                                 .AddOutbound<IIntegrationEvent>(
                                     endpoint => endpoint.ProduceTo(DefaultTopicName))
                                 .AddInbound(
@@ -199,7 +215,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                                 mockedKafkaOptions => mockedKafkaOptions.WithDefaultPartitionsCount(1)))
                         .AddKafkaEndpoints(
                             endpoints => endpoints
-                                .Configure(config => { config.BootstrapServers = "PLAINTEXT://e2e"; })
+                                .Configure(
+                                    config =>
+                                    {
+                                        config.BootstrapServers = "PLAINTEXT://e2e";
+                                    })
                                 .AddOutbound<IIntegrationEvent>(
                                     endpoint => endpoint
                                         .ProduceTo(DefaultTopicName)
@@ -298,7 +318,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                                 mockedKafkaOptions => mockedKafkaOptions.WithDefaultPartitionsCount(1)))
                         .AddKafkaEndpoints(
                             endpoints => endpoints
-                                .Configure(config => { config.BootstrapServers = "PLAINTEXT://e2e"; })
+                                .Configure(
+                                    config =>
+                                    {
+                                        config.BootstrapServers = "PLAINTEXT://e2e";
+                                    })
                                 .AddOutbound<IBinaryFileMessage>(
                                     endpoint => endpoint
                                         .ProduceTo(DefaultTopicName)
@@ -378,7 +402,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                         .WithConnectionToMessageBroker(options => options.AddMockedKafka())
                         .AddKafkaEndpoints(
                             endpoints => endpoints
-                                .Configure(config => { config.BootstrapServers = "PLAINTEXT://e2e"; })
+                                .Configure(
+                                    config =>
+                                    {
+                                        config.BootstrapServers = "PLAINTEXT://e2e";
+                                    })
                                 .AddOutbound<IIntegrationEvent>(
                                     endpoint => endpoint.ProduceTo(DefaultTopicName))
                                 .AddInbound(
@@ -429,7 +457,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                         .WithConnectionToMessageBroker(options => options.AddMockedKafka())
                         .AddKafkaEndpoints(
                             endpoints => endpoints
-                                .Configure(config => { config.BootstrapServers = "PLAINTEXT://e2e"; })
+                                .Configure(
+                                    config =>
+                                    {
+                                        config.BootstrapServers = "PLAINTEXT://e2e";
+                                    })
                                 .AddOutbound<IIntegrationEvent>(
                                     endpoint => endpoint.ProduceTo(DefaultTopicName))
                                 .AddInbound(
@@ -480,7 +512,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                                 mockedKafkaOptions => mockedKafkaOptions.WithDefaultPartitionsCount(1)))
                         .AddKafkaEndpoints(
                             endpoints => endpoints
-                                .Configure(config => { config.BootstrapServers = "PLAINTEXT://e2e"; })
+                                .Configure(
+                                    config =>
+                                    {
+                                        config.BootstrapServers = "PLAINTEXT://e2e";
+                                    })
                                 .AddOutbound<IIntegrationEvent>(
                                     endpoint => endpoint
                                         .ProduceTo(DefaultTopicName)
@@ -540,7 +576,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                                 mockedKafkaOptions => mockedKafkaOptions.WithDefaultPartitionsCount(1)))
                         .AddKafkaEndpoints(
                             endpoints => endpoints
-                                .Configure(config => { config.BootstrapServers = "PLAINTEXT://e2e"; })
+                                .Configure(
+                                    config =>
+                                    {
+                                        config.BootstrapServers = "PLAINTEXT://e2e";
+                                    })
                                 .AddInbound(
                                     endpoint => endpoint
                                         .ConsumeFrom(DefaultTopicName)
@@ -607,7 +647,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                                 mockedKafkaOptions => mockedKafkaOptions.WithDefaultPartitionsCount(1)))
                         .AddKafkaEndpoints(
                             endpoints => endpoints
-                                .Configure(config => { config.BootstrapServers = "PLAINTEXT://e2e"; })
+                                .Configure(
+                                    config =>
+                                    {
+                                        config.BootstrapServers = "PLAINTEXT://e2e";
+                                    })
                                 .AddInbound(
                                     endpoint => endpoint
                                         .ConsumeFrom(DefaultTopicName)
@@ -683,7 +727,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                                 mockedKafkaOptions => mockedKafkaOptions.WithDefaultPartitionsCount(1)))
                         .AddKafkaEndpoints(
                             endpoints => endpoints
-                                .Configure(config => { config.BootstrapServers = "PLAINTEXT://e2e"; })
+                                .Configure(
+                                    config =>
+                                    {
+                                        config.BootstrapServers = "PLAINTEXT://e2e";
+                                    })
                                 .AddInbound(
                                     endpoint => endpoint
                                         .ConsumeFrom(DefaultTopicName)
@@ -793,7 +841,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                         .WithConnectionToMessageBroker(options => options.AddMockedKafka())
                         .AddKafkaEndpoints(
                             endpoints => endpoints
-                                .Configure(config => { config.BootstrapServers = "PLAINTEXT://e2e"; })
+                                .Configure(
+                                    config =>
+                                    {
+                                        config.BootstrapServers = "PLAINTEXT://e2e";
+                                    })
                                 .AddOutbound<IIntegrationEvent>(
                                     endpoint => endpoint
                                         .ProduceTo(DefaultTopicName)
@@ -856,7 +908,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                         .WithConnectionToMessageBroker(options => options.AddMockedKafka())
                         .AddKafkaEndpoints(
                             endpoints => endpoints
-                                .Configure(config => { config.BootstrapServers = "PLAINTEXT://e2e"; })
+                                .Configure(
+                                    config =>
+                                    {
+                                        config.BootstrapServers = "PLAINTEXT://e2e";
+                                    })
                                 .AddOutbound<IIntegrationEvent>(
                                     endpoint => endpoint
                                         .ProduceTo(DefaultTopicName)
@@ -919,7 +975,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                                 mockedKafkaOptions => mockedKafkaOptions.WithDefaultPartitionsCount(1)))
                         .AddKafkaEndpoints(
                             endpoints => endpoints
-                                .Configure(config => { config.BootstrapServers = "PLAINTEXT://e2e"; })
+                                .Configure(
+                                    config =>
+                                    {
+                                        config.BootstrapServers = "PLAINTEXT://e2e";
+                                    })
                                 .AddOutbound<IIntegrationEvent>(
                                     endpoint => endpoint
                                         .ProduceTo(DefaultTopicName))
@@ -978,7 +1038,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                                 mockedKafkaOptions => mockedKafkaOptions.WithDefaultPartitionsCount(1)))
                         .AddKafkaEndpoints(
                             endpoints => endpoints
-                                .Configure(config => { config.BootstrapServers = "PLAINTEXT://e2e"; })
+                                .Configure(
+                                    config =>
+                                    {
+                                        config.BootstrapServers = "PLAINTEXT://e2e";
+                                    })
                                 .AddOutbound<IIntegrationEvent>(
                                     endpoint => endpoint
                                         .ProduceTo(DefaultTopicName))
@@ -1038,7 +1102,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                         .WithConnectionToMessageBroker(options => options.AddMockedKafka())
                         .AddKafkaEndpoints(
                             endpoints => endpoints
-                                .Configure(config => { config.BootstrapServers = "PLAINTEXT://e2e"; })
+                                .Configure(
+                                    config =>
+                                    {
+                                        config.BootstrapServers = "PLAINTEXT://e2e";
+                                    })
                                 .AddOutbound<IIntegrationEvent>(
                                     endpoint => endpoint.ProduceTo(DefaultTopicName))
                                 .AddInbound(
@@ -1047,7 +1115,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                                         .OnError(
                                             policy => policy.MoveToKafkaTopic(
                                                 moveEndpoint => moveEndpoint.ProduceTo("other-topic")))
-                                        .Configure(config => { config.GroupId = "consumer1"; })))
+                                        .Configure(
+                                            config =>
+                                            {
+                                                config.GroupId = "consumer1";
+                                            })))
                         .AddIntegrationSpy()
                         .AddDelegateSubscriber(
                             (IIntegrationEvent _) => throw new InvalidOperationException("Move!")))
@@ -1088,7 +1160,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                         .WithConnectionToMessageBroker(options => options.AddMockedKafka())
                         .AddKafkaEndpoints(
                             endpoints => endpoints
-                                .Configure(config => { config.BootstrapServers = "PLAINTEXT://e2e"; })
+                                .Configure(
+                                    config =>
+                                    {
+                                        config.BootstrapServers = "PLAINTEXT://e2e";
+                                    })
                                 .AddOutbound<IIntegrationEvent>(
                                     endpoint => endpoint.ProduceTo(DefaultTopicName))
                                 .AddInbound(
@@ -1098,7 +1174,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                                             policy => policy.MoveToKafkaTopic(
                                                 moveEndpoint => moveEndpoint.ProduceTo(DefaultTopicName),
                                                 movePolicy => movePolicy.MaxFailedAttempts(10)))
-                                        .Configure(config => { config.GroupId = "consumer1"; })))
+                                        .Configure(
+                                            config =>
+                                            {
+                                                config.GroupId = "consumer1";
+                                            })))
                         .AddIntegrationSpy()
                         .AddDelegateSubscriber(
                             (IIntegrationEvent _) =>
@@ -1137,7 +1217,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                         .WithConnectionToMessageBroker(options => options.AddMockedKafka())
                         .AddKafkaEndpoints(
                             endpoints => endpoints
-                                .Configure(config => { config.BootstrapServers = "PLAINTEXT://e2e"; })
+                                .Configure(
+                                    config =>
+                                    {
+                                        config.BootstrapServers = "PLAINTEXT://e2e";
+                                    })
                                 .AddOutbound<IIntegrationEvent>(
                                     endpoint => endpoint.ProduceTo(DefaultTopicName))
                                 .AddInbound(
@@ -1148,7 +1232,11 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                                                 .Retry(1)
                                                 .ThenMoveToKafkaTopic(
                                                     moveEndpoint => moveEndpoint.ProduceTo("other-topic")))
-                                        .Configure(config => { config.GroupId = "consumer1"; })))
+                                        .Configure(
+                                            config =>
+                                            {
+                                                config.GroupId = "consumer1";
+                                            })))
                         .AddIntegrationSpy()
                         .AddDelegateSubscriber(
                             (IIntegrationEvent _) =>
@@ -1176,6 +1264,103 @@ namespace Silverback.Tests.Integration.E2E.Kafka
             otherTopic.MessagesCount.Should().Be(1);
             otherTopic.GetAllMessages()[0].Value.Should()
                 .BeEquivalentTo(Helper.Spy.InboundEnvelopes[0].RawMessage.ReReadAll());
+        }
+
+        [Fact]
+        public async Task MovePolicy_ToOtherTopic_HeadersSet()
+        {
+            var message1 = new TestEventOne
+            {
+                Content = "Hello E2E msg1."
+            };
+            var message2 = new TestEventOne
+            {
+                Content = "Hello E2E msg2."
+            };
+            var message3 = new TestEventOne
+            {
+                Content = "Hello E2E msg3."
+            };
+
+            Host.ConfigureServices(
+                    services => services
+                        .AddLogging()
+                        .AddSilverback()
+                        .UseModel()
+                        .WithConnectionToMessageBroker(options => options.AddMockedKafka(
+                            mockOptions => mockOptions.WithDefaultPartitionsCount(1)))
+                        .AddKafkaEndpoints(
+                            endpoints => endpoints
+                                .Configure(
+                                    config =>
+                                    {
+                                        config.BootstrapServers = "PLAINTEXT://e2e";
+                                    })
+                                .AddOutbound<IIntegrationEvent>(
+                                    endpoint => endpoint.ProduceTo(DefaultTopicName))
+                                .AddInbound(
+                                    endpoint => endpoint
+                                        .ConsumeFrom(DefaultTopicName)
+                                        .OnError(
+                                            policy => policy.MoveToKafkaTopic(
+                                                moveEndpoint => moveEndpoint.ProduceTo("other-topic")))
+                                        .Configure(
+                                            config =>
+                                            {
+                                                config.GroupId = "consumer1";
+                                            })))
+                        .AddIntegrationSpy()
+                        .AddDelegateSubscriber(
+                            (IIntegrationEvent _) => throw new InvalidOperationException("Move!")))
+                .Run();
+
+            var publisher = Host.ScopedServiceProvider.GetRequiredService<IEventPublisher>();
+            await publisher.PublishAsync(message1);
+            await publisher.PublishAsync(message2);
+            await publisher.PublishAsync(message3);
+            await Helper.WaitUntilAllMessagesAreConsumedAsync();
+
+            Helper.Spy.OutboundEnvelopes.Should().HaveCount(6);
+            Helper.Spy.InboundEnvelopes.Should().HaveCount(3);
+
+            var otherTopic = Helper.GetTopic("other-topic");
+            var otherTopicMessages = otherTopic.GetAllMessages();
+            otherTopic.MessagesCount.Should().Be(3);
+
+            otherTopicMessages[0].Value.Should()
+                .BeEquivalentTo(Helper.Spy.InboundEnvelopes[0].RawMessage.ReReadAll());
+            otherTopicMessages[1].Value.Should()
+                .BeEquivalentTo(Helper.Spy.InboundEnvelopes[1].RawMessage.ReReadAll());
+            otherTopicMessages[2].Value.Should()
+                .BeEquivalentTo(Helper.Spy.InboundEnvelopes[2].RawMessage.ReReadAll());
+
+            Helper.Spy.OutboundEnvelopes[5].Endpoint.Name.Should().Be("other-topic");
+            Helper.Spy.OutboundEnvelopes[5].Headers
+                .Should().ContainEquivalentOf(
+                    new MessageHeader(
+                        DefaultMessageHeaders.FailedAttempts,
+                        1));
+            Helper.Spy.OutboundEnvelopes[5].Headers
+                .Should().ContainEquivalentOf(
+                    new MessageHeader(
+                        DefaultMessageHeaders.FailureReason,
+                        "System.Reflection.TargetInvocationException in System.Private.CoreLib"));
+            Helper.Spy.OutboundEnvelopes[5].Headers
+                .Count(header => header.Name == KafkaMessageHeaders.SourceTimestamp)
+                .Should().Be(1);
+            Helper.Spy.OutboundEnvelopes[5].Headers
+                .Any(header => header.Name == KafkaMessageHeaders.TimestampKey)
+                .Should().BeTrue();
+            Helper.Spy.OutboundEnvelopes[5].Headers
+                .Should().ContainEquivalentOf(
+                    new MessageHeader(
+                        KafkaMessageHeaders.SourcePartition,
+                        0));
+            Helper.Spy.OutboundEnvelopes[5].Headers
+                .Should().ContainEquivalentOf(
+                    new MessageHeader(
+                        KafkaMessageHeaders.SourceOffset,
+                        2));
         }
     }
 }

--- a/tests/Silverback.Integration.Tests/Messaging/ErrorHandling/MoveMessageErrorPolicyTests.cs
+++ b/tests/Silverback.Integration.Tests/Messaging/ErrorHandling/MoveMessageErrorPolicyTests.cs
@@ -273,33 +273,7 @@ namespace Silverback.Tests.Integration.Messaging.ErrorHandling
 
             var producer = (TestProducer)_broker.GetProducer(TestProducerEndpoint.GetDefault());
             var newHeaders = producer.ProducedMessages[0].Headers;
-            newHeaders.Should().HaveCount(5); // key, x-source-endpoint, error, traceparent, message-id
-        }
-
-        [Fact]
-        public async Task HandleErrorAsync_SingleMessage_SourceEndpointHeaderIsSet()
-        {
-            var policy = new MoveMessageErrorPolicy(TestProducerEndpoint.GetDefault()).Build(_serviceProvider);
-            var envelope = new InboundEnvelope(
-                "hey oh!",
-                new MemoryStream(Encoding.UTF8.GetBytes("hey oh!")),
-                null,
-                new TestOffset(),
-                new TestConsumerEndpoint("source-endpoint"),
-                "source-endpoint");
-
-            await policy.HandleErrorAsync(
-                ConsumerPipelineContextHelper.CreateSubstitute(envelope, _serviceProvider),
-                new InvalidOperationException("test"));
-
-            var producer = (TestProducer)_broker.GetProducer(TestProducerEndpoint.GetDefault());
-
-            producer.ProducedMessages.Last()
-                .Headers
-                .Should().ContainEquivalentOf(
-                    new MessageHeader(
-                        DefaultMessageHeaders.SourceEndpoint,
-                        "source-endpoint"));
+            newHeaders.Should().HaveCount(4); // key, error, traceparent, message-id
         }
 
         [Fact]


### PR DESCRIPTION
I implemented a new move policy for Kafka to enrich the moved message with some custom headers with information about the original message (source-topic, source-partition, source-offset, ...).