### PR TITLE
fix: get the innermost exception for x-failure-reason

### DIFF
--- a/src/Silverback.Integration.Kafka/Messaging/Outbound/Enrichers/KafkaMovePolicyMessageEnricher.cs
+++ b/src/Silverback.Integration.Kafka/Messaging/Outbound/Enrichers/KafkaMovePolicyMessageEnricher.cs
@@ -21,6 +21,12 @@ namespace Silverback.Messaging.Outbound.Enrichers
             outboundEnvelope.Headers.AddOrReplace(
                 KafkaMessageHeaders.SourceConsumerGroupId,
                 ((KafkaConsumerEndpoint)inboundEnvelope.Endpoint).Configuration.GroupId);
+
+            while (exception.InnerException != null)
+            {
+                exception = exception.InnerException;
+            }
+
             outboundEnvelope.Headers.AddOrReplace(
                 DefaultMessageHeaders.FailureReason,
                 $"{exception.GetType().FullName} in {exception.Source}");

--- a/tests/Silverback.Integration.Tests.E2E/Kafka/ErrorHandlingTests.cs
+++ b/tests/Silverback.Integration.Tests.E2E/Kafka/ErrorHandlingTests.cs
@@ -1345,7 +1345,7 @@ namespace Silverback.Tests.Integration.E2E.Kafka
                 .Should().ContainEquivalentOf(
                     new MessageHeader(
                         DefaultMessageHeaders.FailureReason,
-                        "System.Reflection.TargetInvocationException in System.Private.CoreLib"));
+                        "System.InvalidOperationException in Silverback.Integration.Tests.E2E"));
             Helper.Spy.OutboundEnvelopes[5].Headers
                 .Count(header => header.Name == KafkaMessageHeaders.SourceTimestamp)
                 .Should().Be(1);


### PR DESCRIPTION
Gets the innermost exception to use for the x-failure-reason header.