### PR TITLE
fix: null check for message UserProperties

### DIFF
--- a/src/Silverback.Integration.MQTT/Messaging/Broker/MqttConsumer.cs
+++ b/src/Silverback.Integration.MQTT/Messaging/Broker/MqttConsumer.cs
@@ -69,7 +69,7 @@ namespace Silverback.Messaging.Broker
         internal async Task HandleMessageAsync(ConsumedApplicationMessage message)
         {
             var headers = Endpoint.Configuration.AreHeadersSupported
-                ? new MessageHeaderCollection(message.ApplicationMessage.UserProperties.ToSilverbackHeaders())
+                ? new MessageHeaderCollection(message.ApplicationMessage.UserProperties?.ToSilverbackHeaders())
                 : new MessageHeaderCollection();
 
             headers.AddIfNotExists(DefaultMessageHeaders.MessageId, message.Id);


### PR DESCRIPTION
After the update to MQTTnet 4.x the UserProperties of a message without user properties were null and caused an error in the method ToSilverbackHeaders.