### PR TITLE
fix: Handle exceptions in OutboxQueueHealthCheck (#219)

### DIFF
--- a/src/Silverback.Core/Justifications.cs
+++ b/src/Silverback.Core/Justifications.cs
@@ -37,5 +37,8 @@ namespace Silverback
 
         public const string ExecutesSyncOrAsync =
             "The method executes either synchronously or asynchronously";
+
+        public const string CatchAllExceptions =
+            "All exception types require catching";
     }
 }

--- a/tests/Silverback.Integration.HealthChecks.Tests/Messaging/HealthChecks/OutboxQueueHealthCheckTests.cs
+++ b/tests/Silverback.Integration.HealthChecks.Tests/Messaging/HealthChecks/OutboxQueueHealthCheckTests.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) 2020 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Silverback.Database;
+using Silverback.Messaging.HealthChecks;
+using Silverback.Messaging.Outbound.TransactionalOutbox.Repositories;
+using Xunit;
+
+namespace Silverback.Tests.Integration.HealthChecks.Messaging.HealthChecks
+{
+    public class OutboxQueueHealthCheckTests
+    {
+        [Fact]
+        public async Task CheckHealthAsync_ExceptionThrown_UnhealthyReturned()
+        {
+            var outboundQueueHealthCheckService = Substitute.For<IOutboundQueueHealthCheckService>();
+            outboundQueueHealthCheckService.CheckIsHealthyAsync(Arg.Any<TimeSpan>()).ThrowsAsync(new TimeoutException());
+
+            var outboundQueueHealthCheck = new OutboxQueueHealthCheck(outboundQueueHealthCheckService);
+
+            var serviceProvider = ServiceProviderHelper.GetServiceProvider(
+                services => services
+                    .AddSilverback()
+                    .WithConnectionToMessageBroker(options => options
+                        .AddKafka()
+                        .AddOutbox<DbOutboxWriter, DbOutboxReader>())
+                    .Services
+                    .AddSingleton(outboundQueueHealthCheckService)
+                    .AddSingleton(Substitute.For<IDbContext>())
+                    .AddHealthChecks()
+                    .Add(new HealthCheckRegistration("OutboundQueue", outboundQueueHealthCheck, default, default)));
+
+            var (healthCheck, context) = GetHealthCheck(serviceProvider);
+
+            var result = await healthCheck.CheckHealthAsync(context);
+
+            result.Status.Should().Be(HealthStatus.Unhealthy);
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_ExceptionThrown_ExceptionReturned()
+        {
+            var outboundQueueHealthCheckService = Substitute.For<IOutboundQueueHealthCheckService>();
+            TimeoutException exceptionToBeThrown = new TimeoutException();
+            outboundQueueHealthCheckService.CheckIsHealthyAsync(Arg.Any<TimeSpan>()).ThrowsAsync(exceptionToBeThrown);
+
+            var outboundQueueHealthCheck = new OutboxQueueHealthCheck(outboundQueueHealthCheckService);
+
+            var serviceProvider = ServiceProviderHelper.GetServiceProvider(
+                services => services
+                    .AddSilverback()
+                    .WithConnectionToMessageBroker(options => options
+                        .AddKafka()
+                        .AddOutbox<DbOutboxWriter, DbOutboxReader>())
+                    .Services
+                    .AddSingleton(outboundQueueHealthCheckService)
+                    .AddSingleton(Substitute.For<IDbContext>())
+                    .AddHealthChecks()
+                    .Add(new HealthCheckRegistration("OutboundQueue", outboundQueueHealthCheck, default, default)));
+
+            var (healthCheck, context) = GetHealthCheck(serviceProvider);
+
+            var result = await healthCheck.CheckHealthAsync(context);
+
+            result.Exception.Should().Be(exceptionToBeThrown);
+        }
+
+        [Theory]
+        [InlineData(true, HealthStatus.Healthy)]
+        [InlineData(false, HealthStatus.Unhealthy)]
+        public async Task CheckHealthAsync_HealthyCheck_ReturnsExpectedStatus(bool healthy, HealthStatus expectedStatus)
+        {
+            var outboundQueueHealthCheckService = Substitute.For<IOutboundQueueHealthCheckService>();
+            outboundQueueHealthCheckService.CheckIsHealthyAsync(Arg.Any<TimeSpan>()).Returns(healthy);
+
+            var outboundQueueHealthCheck = new OutboxQueueHealthCheck(outboundQueueHealthCheckService);
+
+            var serviceProvider = ServiceProviderHelper.GetServiceProvider(
+                services => services
+                    .AddSilverback()
+                    .WithConnectionToMessageBroker(options => options
+                        .AddKafka()
+                        .AddOutbox<DbOutboxWriter, DbOutboxReader>())
+                    .Services
+                    .AddSingleton(outboundQueueHealthCheckService)
+                    .AddSingleton(Substitute.For<IDbContext>())
+                    .AddHealthChecks()
+                    .Add(new HealthCheckRegistration("OutboundQueue", outboundQueueHealthCheck, default, default)));
+
+            var (healthCheck, context) = GetHealthCheck(serviceProvider);
+
+            var result = await healthCheck.CheckHealthAsync(context);
+
+            result.Status.Should().Be(expectedStatus);
+        }
+
+        private static (IHealthCheck HealthCheck, HealthCheckContext Context) GetHealthCheck(IServiceProvider serviceProvider)
+        {
+            var healthCheckOptions = serviceProvider
+                .GetRequiredService<IOptions<HealthCheckServiceOptions>>();
+
+            var context = new HealthCheckContext
+            {
+                Registration = healthCheckOptions.Value.Registrations.First()
+            };
+
+            return (context.Registration.Factory.Invoke(serviceProvider), context);
+        }
+    }
+}

--- a/tests/Silverback.Integration.HealthChecks.Tests/Silverback.Integration.HealthChecks.Tests.csproj
+++ b/tests/Silverback.Integration.HealthChecks.Tests/Silverback.Integration.HealthChecks.Tests.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Silverback.Core.EFCore30\Silverback.Core.EFCore30.csproj" />
     <ProjectReference Include="..\..\src\Silverback.Integration.HealthChecks\Silverback.Integration.HealthChecks.csproj" />
+    <ProjectReference Include="..\..\src\Silverback.Integration.Kafka\Silverback.Integration.Kafka.csproj" />
     <ProjectReference Include="..\Silverback.Tests.Common.Integration\Silverback.Tests.Common.Integration.csproj" />
     <ProjectReference Include="..\Silverback.Tests.Common\Silverback.Tests.Common.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Handle exceptions in OutboxQueueHealthCheck and return unhealthy result if exception is caught