### PR TITLE
fix: prevent invalid nested objects to be considered valid

### DIFF
--- a/src/Silverback.Integration/Messaging/Validation/MessageValidator.cs
+++ b/src/Silverback.Integration/Messaging/Validation/MessageValidator.cs
@@ -63,12 +63,16 @@ namespace Silverback.Messaging.Validation
                 {
                     foreach (object? valueItem in valueEnumerable)
                     {
-                        result = ValidateNestedObject(valueItem, results);
+                        bool nextResult = ValidateNestedObject(valueItem, results);
+                        if (result)
+                            result = nextResult;
                     }
                 }
                 else
                 {
-                    result = ValidateNestedObject(value, results);
+                    bool nextResult = ValidateNestedObject(value, results);
+                    if (result)
+                        result = nextResult;
                 }
             }
 

--- a/tests/Silverback.Integration.Tests/Messaging/Validation/ValidatorConsumerBehaviorTests.cs
+++ b/tests/Silverback.Integration.Tests/Messaging/Validation/ValidatorConsumerBehaviorTests.cs
@@ -162,12 +162,50 @@ namespace Silverback.Tests.Integration.Messaging.Validation
                         String10 = "123456",
                         IntRange = 5,
                         NumbersOnly = "123",
-                        Nested = new ValidationMessageNestedModel
+                        FirstNested = new ValidationMessageNestedModel
                         {
                             String5 = "123456"
                         }
                     },
                     $"An invalid message has been processed. | validation errors:{Environment.NewLine}- The field String5 must be a string with a maximum length of 5."
+                };
+                yield return new object[]
+{
+                    new TestValidationMessage
+                    {
+                        Id = "1",
+                        String10 = "123456",
+                        IntRange = 5,
+                        NumbersOnly = "123",
+                        FirstNested = new ValidationMessageNestedModel
+                        {
+                            String5 = "123456"
+                        },
+                        SecondNested = new ValidationMessageNestedModel
+                        {
+                            String5 = "12345"
+                        }
+                    },
+                    $"An invalid message has been processed. | validation errors:{Environment.NewLine}- The field String5 must be a string with a maximum length of 5."
+};
+                yield return new object[]
+                {
+                    new TestValidationMessage
+                    {
+                        Id = "1",
+                        String10 = "123456",
+                        IntRange = 5,
+                        NumbersOnly = "123",
+                        FirstNested = new ValidationMessageNestedModel
+                        {
+                            String5 = "123456"
+                        },
+                        SecondNested = new ValidationMessageNestedModel
+                        {
+                            String5 = "123456"
+                        }
+                    },
+                    $"An invalid message has been processed. | validation errors:{Environment.NewLine}- The field String5 must be a string with a maximum length of 5.{Environment.NewLine}- The field String5 must be a string with a maximum length of 5."
                 };
             }
         }
@@ -207,7 +245,7 @@ namespace Silverback.Tests.Integration.Messaging.Validation
         public async Task HandleAsync_ValidMessage_NoLogAndNoException(MessageValidationMode validationMode)
         {
             var message = new TestValidationMessage
-                { Id = "1", String10 = "123", IntRange = 5, NumbersOnly = "123" };
+            { Id = "1", String10 = "123", IntRange = 5, NumbersOnly = "123" };
             var endpoint = TestConsumerEndpoint.GetDefault();
             endpoint.MessageValidationMode = validationMode;
 
@@ -266,7 +304,7 @@ namespace Silverback.Tests.Integration.Messaging.Validation
         public async Task HandleAsync_ThrowException_ExceptionIsThrown()
         {
             var message = new TestValidationMessage
-                { Id = "1", String10 = "123456789abc", IntRange = 5, NumbersOnly = "123" };
+            { Id = "1", String10 = "123456789abc", IntRange = 5, NumbersOnly = "123" };
             var expectedMessage =
                 $"The message is not valid:{Environment.NewLine}- The field String10 must be a string with a maximum length of 10.";
             var endpoint = TestConsumerEndpoint.GetDefault();

--- a/tests/Silverback.Integration.Tests/Messaging/Validation/ValidatorProducerBehaviorTests.cs
+++ b/tests/Silverback.Integration.Tests/Messaging/Validation/ValidatorProducerBehaviorTests.cs
@@ -162,12 +162,50 @@ namespace Silverback.Tests.Integration.Messaging.Validation
                         String10 = "123456",
                         IntRange = 5,
                         NumbersOnly = "123",
-                        Nested = new ValidationMessageNestedModel
+                        FirstNested = new ValidationMessageNestedModel
                         {
                             String5 = "123456"
                         }
                     },
                     $"An invalid message has been produced. | validation errors:{Environment.NewLine}- The field String5 must be a string with a maximum length of 5."
+                };
+                yield return new object[]
+                {
+                    new TestValidationMessage
+                    {
+                        Id = "1",
+                        String10 = "123456",
+                        IntRange = 5,
+                        NumbersOnly = "123",
+                        FirstNested = new ValidationMessageNestedModel
+                        {
+                            String5 = "123456"
+                        },
+                        SecondNested = new ValidationMessageNestedModel
+                        {
+                            String5 = "12345"
+                        }
+                    },
+                    $"An invalid message has been produced. | validation errors:{Environment.NewLine}- The field String5 must be a string with a maximum length of 5."
+                };
+                yield return new object[]
+                {
+                    new TestValidationMessage
+                    {
+                        Id = "1",
+                        String10 = "123456",
+                        IntRange = 5,
+                        NumbersOnly = "123",
+                        FirstNested = new ValidationMessageNestedModel
+                        {
+                            String5 = "123456"
+                        },
+                        SecondNested = new ValidationMessageNestedModel
+                        {
+                            String5 = "123456"
+                        }
+                    },
+                    $"An invalid message has been produced. | validation errors:{Environment.NewLine}- The field String5 must be a string with a maximum length of 5.{Environment.NewLine}- The field String5 must be a string with a maximum length of 5."
                 };
             }
         }
@@ -204,7 +242,7 @@ namespace Silverback.Tests.Integration.Messaging.Validation
         public async Task HandleAsync_ValidMessage_NoLogAndNoException(MessageValidationMode validationMode)
         {
             var message = new TestValidationMessage
-                { Id = "1", String10 = "123", IntRange = 5, NumbersOnly = "123" };
+            { Id = "1", String10 = "123", IntRange = 5, NumbersOnly = "123" };
             var endpoint = TestProducerEndpoint.GetDefault();
             endpoint.MessageValidationMode = validationMode;
             var envelope = new OutboundEnvelope(message, null, endpoint);
@@ -258,7 +296,7 @@ namespace Silverback.Tests.Integration.Messaging.Validation
         public async Task HandleAsync_ThrowException_ExceptionIsThrown()
         {
             var message = new TestValidationMessage
-                { Id = "1", String10 = "123456789abc", IntRange = 5, NumbersOnly = "123" };
+            { Id = "1", String10 = "123456789abc", IntRange = 5, NumbersOnly = "123" };
             var expectedMessage =
                 $"The message is not valid:{Environment.NewLine}- The field String10 must be a string with a maximum length of 10.";
             var endpoint = TestProducerEndpoint.GetDefault();

--- a/tests/Silverback.Tests.Common.Integration/Types/Domain/TestValidationMessage.cs
+++ b/tests/Silverback.Tests.Common.Integration/Types/Domain/TestValidationMessage.cs
@@ -28,6 +28,8 @@ namespace Silverback.Tests.Types.Domain
         [RegularExpression("^[0-9]*$")]
         public string NumbersOnly { get; set; } = null!;
 
-        public ValidationMessageNestedModel? Nested { get; set; }
+        public ValidationMessageNestedModel? FirstNested { get; set; }
+
+        public ValidationMessageNestedModel? SecondNested { get; set; }
     }
 }


### PR DESCRIPTION
Hello there,

We have issues with the MessageValidation and discovered that it only works partially.

Currently it works if there is an invalid property at parent level, and or in the last nested object that is being validated. Any invalid nested object in between goes into the validation logic but it's result will be erased by the last nested object. If the last object is valid then the message is considered valid, which is an issue.

This PR fixes this behavior by validating all nested objects but, once an invalid object is found the result is not being set anymore. So once there was an invalid message the result will stay false.

The bug can be reproduced by running the new tests without the fix.

I am unsure if we should consider this a breaking change. It could have a major impact on running systems.

Best