### PR TITLE
test: add Coyote systematic concurrency tests for SequenceBase

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,8 @@
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.7.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.103" />
+    <PackageVersion Include="Microsoft.Coyote" Version="1.7.11" />
+    <PackageVersion Include="Microsoft.Coyote.Test" Version="1.7.11" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="10.0.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />

--- a/Silverback.sln
+++ b/Silverback.sln
@@ -130,6 +130,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Silverback.Storage.Relation
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Silverback.Tools.Generators.Docs.Headers", "tools\Silverback.Tools.Generators.Docs.Headers\Silverback.Tools.Generators.Docs.Headers.csproj", "{5AB6F39A-5B87-461D-9E6A-C2847016AC7D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Silverback.Tests.Concurrency", "tests\Silverback.Tests.Concurrency\Silverback.Tests.Concurrency.csproj", "{C07E10A1-CC00-4FFF-A0A0-000000000001}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -308,6 +310,10 @@ Global
 		{5AB6F39A-5B87-461D-9E6A-C2847016AC7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5AB6F39A-5B87-461D-9E6A-C2847016AC7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5AB6F39A-5B87-461D-9E6A-C2847016AC7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C07E10A1-CC00-4FFF-A0A0-000000000001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C07E10A1-CC00-4FFF-A0A0-000000000001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C07E10A1-CC00-4FFF-A0A0-000000000001}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C07E10A1-CC00-4FFF-A0A0-000000000001}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -342,6 +348,7 @@ Global
 		{5244CA89-97CA-418E-8976-357057A104F6} = {6AFB87A3-501B-4A87-B94C-205AEB118D97}
 		{9C26779F-D843-4B87-BCE5-ABC283E6A16B} = {6AFB87A3-501B-4A87-B94C-205AEB118D97}
 		{5AB6F39A-5B87-461D-9E6A-C2847016AC7D} = {9818A770-01ED-4340-BD4A-CFDDA6C56168}
+		{C07E10A1-CC00-4FFF-A0A0-000000000001} = {6AFB87A3-501B-4A87-B94C-205AEB118D97}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {89DA4AF5-B982-42AD-A829-8A72BCB21227}

--- a/tests/Silverback.Integration.Tests/Messaging/Sequences/SequenceBaseSemaphoreLeakTests.cs
+++ b/tests/Silverback.Integration.Tests/Messaging/Sequences/SequenceBaseSemaphoreLeakTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System;
+using System.Threading.Tasks;
+using Shouldly;
+using Silverback.Messaging.Broker.Behaviors;
+using Silverback.Messaging.Sequences;
+using Silverback.Messaging.Sequences.Chunking;
+using Xunit;
+
+namespace Silverback.Tests.Integration.Messaging.Sequences;
+
+// Non-Coyote reproducer for a semaphore leak in SequenceBase<TEnvelope>.AbortIfIncompleteAsync.
+// When the sequence is already aborted (or completed), AbortIfIncompleteAsync acquires
+// _completeSemaphoreSlim and then early-returns on the !IsPending check without releasing
+// it. The leak only bites on the next synchronous wait on that semaphore, which happens
+// inside Dispose().
+public class SequenceBaseSemaphoreLeakTests
+{
+    [Fact]
+    public async Task AbortIfIncompleteAsync_AfterAbort_ShouldNotLeakCompleteSemaphore()
+    {
+        ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
+        ChunkSequence sequence = new("leak-test", 10, context);
+
+        await sequence.AbortAsync(SequenceAbortReason.IncompleteSequence);
+        sequence.IsAborted.ShouldBeTrue();
+
+        // This is the call that leaks: it acquires _completeSemaphoreSlim, sees !IsPending,
+        // and returns without releasing.
+        await sequence.AbortIfIncompleteAsync();
+
+        // Dispose() performs a synchronous Wait() on _completeSemaphoreSlim. If the semaphore
+        // is leaked it will block here forever; we wrap the call in Task.Run with a timeout so
+        // the test fails cleanly rather than hanging.
+        Task disposeTask = Task.Run(sequence.Dispose);
+        Task finished = await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromSeconds(5)));
+
+        finished.ShouldBe(disposeTask, "Dispose() blocked — AbortIfIncompleteAsync leaked _completeSemaphoreSlim.");
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/SequenceAbortCoyoteTests.cs
+++ b/tests/Silverback.Tests.Concurrency/SequenceAbortCoyoteTests.cs
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Coyote.SystematicTesting;
+using Shouldly;
+using Silverback.Messaging.Broker.Behaviors;
+using Silverback.Messaging.Sequences;
+using Xunit;
+using Xunit.Abstractions;
+using CoyoteConfiguration = Microsoft.Coyote.Configuration;
+
+namespace Silverback.Tests.Concurrency;
+
+// Systematic concurrency tests for SequenceBase<TEnvelope> completion / abort synchronization,
+// executed under the Microsoft Coyote scheduler.
+//
+// Each [Fact] wraps a self-contained async test body in Coyote's TestingEngine, which explores
+// different interleavings of the Task-based plumbing. A run is considered successful if no bug
+// is found across all scheduled iterations; otherwise we fail the xunit test and emit Coyote's
+// replay report (which includes a deterministic schedule to reproduce the bug).
+//
+// The assemblies under test (Silverback.Core, Silverback.Integration, and this test DLL) are
+// binary-rewritten by `coyote rewrite` as a post-build step in the .csproj so that async
+// state machines, SemaphoreSlim, Task.Run, etc. are intercepted by Coyote.
+public class SequenceAbortCoyoteTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public SequenceAbortCoyoteTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void ConcurrentAbort_ShouldReachAbortedStateExactlyOnce()
+    {
+        RunCoyoteTest(
+            async () =>
+            {
+                ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
+                using TestSequence sequence = new("seq-concurrent-abort", context);
+
+                Task abort1 = sequence.AbortAsync(SequenceAbortReason.IncompleteSequence);
+                Task abort2 = sequence.AbortAsync(SequenceAbortReason.IncompleteSequence);
+                Task abort3 = sequence.AbortAsync(SequenceAbortReason.IncompleteSequence);
+
+                await Task.WhenAll(abort1, abort2, abort3).ConfigureAwait(false);
+
+                // Invariants: once any abort has returned, the sequence must be consistently
+                // aborted; it must never be pending, and the abort reason must be the one we
+                // requested (no spurious upgrade from the idempotent path).
+                sequence.IsAborted.ShouldBeTrue();
+                sequence.IsPending.ShouldBeFalse();
+                sequence.AbortReason.ShouldBe(SequenceAbortReason.IncompleteSequence);
+            });
+    }
+
+    [Fact]
+    public void AbortThenAbortIfIncomplete_ShouldBothReturnAndRemainAborted()
+    {
+        RunCoyoteTest(
+            async () =>
+            {
+                ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
+                using TestSequence sequence = new("seq-abort-plus-abort-if-incomplete", context);
+
+                Task abort = sequence.AbortAsync(SequenceAbortReason.Error, new InvalidOperationException("boom"));
+                Task abortIfIncomplete = sequence.AbortIfIncompleteAsync();
+
+                await Task.WhenAll(abort, abortIfIncomplete).ConfigureAwait(false);
+
+                // The first abort carries the higher-priority reason (Error) and must win.
+                // AbortIfIncompleteAsync racing against it must not downgrade the reason nor
+                // leave the sequence in a partially-aborted state.
+                sequence.IsAborted.ShouldBeTrue();
+                sequence.IsPending.ShouldBeFalse();
+                sequence.AbortReason.ShouldBe(SequenceAbortReason.Error);
+            });
+    }
+
+    [Fact]
+    public void ConcurrentAbortMix_ShouldConvergeToSingleAbortedStateWithoutSemaphoreLeak()
+    {
+        // Three concurrent tasks: two AbortAsync(IncompleteSequence) and one AbortIfIncompleteAsync.
+        // This mixes the two code paths that both take _completeSemaphoreSlim, so any
+        // release-path asymmetry (such as the bug we found and fixed in AbortIfIncompleteAsync)
+        // will manifest as either a deadlock or a stuck semaphore that Dispose() then hits.
+        RunCoyoteTest(
+            async () =>
+            {
+                ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
+                using TestSequence sequence = new("seq-abort-mix", context);
+
+                Task abort1 = sequence.AbortAsync(SequenceAbortReason.IncompleteSequence);
+                Task abort2 = sequence.AbortAsync(SequenceAbortReason.IncompleteSequence);
+                Task abortIfIncomplete = sequence.AbortIfIncompleteAsync();
+
+                await Task.WhenAll(abort1, abort2, abortIfIncomplete).ConfigureAwait(false);
+
+                sequence.IsAborted.ShouldBeTrue();
+                sequence.IsPending.ShouldBeFalse();
+                sequence.AbortReason.ShouldBe(SequenceAbortReason.IncompleteSequence);
+            });
+    }
+
+    [Fact]
+    public void ConcurrentErrorAborts_ShouldSetAbortExceptionExactlyOnce()
+    {
+        // Two concurrent AbortAsync(Error, ...) calls. The first to acquire _completeSemaphoreSlim
+        // should set AbortException; the second should observe IsAborted, wait on
+        // _abortingTaskCompletionSource, and return. AbortException must be exactly one of the two
+        // exceptions we passed in — no null, no partial state.
+        RunCoyoteTest(
+            async () =>
+            {
+                ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
+                using TestSequence sequence = new("seq-concurrent-error", context);
+
+                InvalidOperationException ex1 = new("first");
+                InvalidOperationException ex2 = new("second");
+
+                Task abort1 = sequence.AbortAsync(SequenceAbortReason.Error, ex1);
+                Task abort2 = sequence.AbortAsync(SequenceAbortReason.Error, ex2);
+
+                await Task.WhenAll(abort1, abort2).ConfigureAwait(false);
+
+                sequence.IsAborted.ShouldBeTrue();
+                sequence.AbortReason.ShouldBe(SequenceAbortReason.Error);
+                sequence.AbortException.ShouldNotBeNull();
+                Exception abortException = sequence.AbortException;
+                (abortException == ex1 || abortException == ex2).ShouldBeTrue(
+                    "AbortException must be one of the exceptions that was passed in, not a wrapper or null.");
+            });
+    }
+
+    private void RunCoyoteTest(Func<Task> testBody, int iterations = 100)
+    {
+        CoyoteConfiguration config = CoyoteConfiguration.Create()
+            .WithTestingIterations((uint)iterations)
+            .WithVerbosityEnabled()
+            .WithConsoleLoggingEnabled();
+
+        TestingEngine engine = TestingEngine.Create(config, testBody);
+        engine.Run();
+
+        string report = engine.GetReport();
+        _output.WriteLine(report);
+
+        if (engine.TestReport.NumOfFoundBugs > 0)
+        {
+            string bugReports = string.Join("\n---\n", engine.TestReport.BugReports);
+            _output.WriteLine("Bug reports:");
+            _output.WriteLine(bugReports);
+            throw new Xunit.Sdk.XunitException(
+                $"Coyote found {engine.TestReport.NumOfFoundBugs} bug(s) across {iterations} iterations.\n\n{report}\n\nBug reports:\n{bugReports}");
+        }
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/Silverback.Tests.Concurrency.csproj
+++ b/tests/Silverback.Tests.Concurrency/Silverback.Tests.Concurrency.csproj
@@ -1,0 +1,54 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(TestsTargetFrameworks)</TargetFrameworks>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <RootNamespace>Silverback.Tests.Concurrency</RootNamespace>
+    <LangVersion>$(LangVersion)</LangVersion>
+    <!--
+      Analyzers produce a lot of noise in Coyote test code (intentional sync-over-async,
+      Task.Run inside test bodies, etc.). Keep them off to mirror how Coyote samples ship.
+    -->
+    <AnalysisMode>None</AnalysisMode>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CA1707;CA2007;VSTHRD002;VSTHRD003;VSTHRD200;SA0001;SA1600;SA1633</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Coyote" />
+    <PackageReference Include="Microsoft.Coyote.Test" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Silverback.Integration\Silverback.Integration.csproj" />
+    <ProjectReference Include="..\Silverback.Tests.Common.Integration\Silverback.Tests.Common.Integration.csproj" />
+    <ProjectReference Include="..\Silverback.Tests.Common\Silverback.Tests.Common.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="rewrite.coyote.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\xunit.runner.json">
+      <Link>xunit.runner.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <!--
+    After build, invoke `coyote rewrite` on the test output directory so that xunit picks up
+    rewritten Silverback.* and test assemblies. DOTNET_ROLL_FORWARD=Major is needed because
+    Microsoft.Coyote.CLI 1.7.11 ships as net8.0 and this solution targets net10.0 only.
+  -->
+  <Target Name="CoyoteRewrite" AfterTargets="Build" Condition="'$(SkipCoyoteRewrite)' != 'true'">
+    <Message Text="Running coyote rewrite against $(OutputPath)" Importance="high" />
+    <Exec Command="coyote rewrite &quot;$(MSBuildProjectDirectory)\rewrite.coyote.json&quot;"
+          WorkingDirectory="$(MSBuildProjectDirectory)"
+          EnvironmentVariables="DOTNET_ROLL_FORWARD=Major" />
+  </Target>
+</Project>

--- a/tests/Silverback.Tests.Concurrency/TestSequence.cs
+++ b/tests/Silverback.Tests.Concurrency/TestSequence.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using Silverback.Messaging.Broker.Behaviors;
+using Silverback.Messaging.Sequences;
+
+namespace Silverback.Tests.Concurrency;
+
+// A minimal concrete SequenceBase for Coyote tests. We subclass RawSequence rather than
+// BatchSequence/ChunkSequence to avoid pulling in the timeout timer (a fire-and-forget
+// Task.Run polling loop) and the chunk-ordering state machine, neither of which is
+// relevant to the completion/abort synchronization we want Coyote to explore.
+internal sealed class TestSequence : RawSequence
+{
+    public TestSequence(string sequenceId, ConsumerPipelineContext context)
+        : base(sequenceId, context, enforceTimeout: false)
+    {
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/rewrite.coyote.json
+++ b/tests/Silverback.Tests.Concurrency/rewrite.coyote.json
@@ -1,0 +1,10 @@
+{
+  "AssembliesPath": "bin/Debug/net10.0",
+  "Assemblies": [
+    "Silverback.Core.dll",
+    "Silverback.Integration.dll",
+    "Silverback.Tests.Concurrency.dll"
+  ],
+  "IsRewritingThreads": true,
+  "IsRewritingConcurrentCollections": true
+}


### PR DESCRIPTION
## Summary

Adds a `Silverback.Tests.Concurrency` test project built on [Microsoft Coyote](https://microsoft.github.io/coyote/) that systematically explores `Task` interleavings in `SequenceBase<TEnvelope>` completion / abort synchronization. Coyote's `TestingEngine` runs each test across ~100 scheduled interleavings and multiple strategies (random, probabilistic, fair-prioritization, fair-delay-bounding) on binary-rewritten Silverback assemblies.

A post-build MSBuild target invokes `coyote rewrite` against the test project's output directory so that `Silverback.Core.dll`, `Silverback.Integration.dll`, and the test assembly itself are rewritten before `dotnet test` runs. No source changes are required in the Silverback projects.

## Bug surfaced (not fixed in this PR)

The test suite caught a semaphore leak in `SequenceBase<TEnvelope>.AbortIfIncompleteAsync` (introduced in 3db53b53):

` ` ` csharp
public async Task AbortIfIncompleteAsync()
{
    if (!await WaitIfNotDisposedAsync(_completeSemaphoreSlim).ConfigureAwait(false))
        return;

    if (!IsPending)
        return;                              // <-- leaks _completeSemaphoreSlim

    try
    {
        await AbortCoreAsync(SequenceAbortReason.IncompleteSequence, null).ConfigureAwait(false);
    }
    finally
    {
        _completeSemaphoreSlim.Release();
    }
}
` ` `

After acquiring `_completeSemaphoreSlim`, the `!IsPending` early-return exits without hitting the `finally` that would release it. The leak stays latent until the next synchronous wait on that semaphore, which happens inside `Dispose()` at line 467 and produces a deterministic deadlock. The fix is a one-line move of the early-return into the existing `try/finally` block; it is intentionally left out of this PR so the tooling lands separately from the behavioral change.

A non-Coyote reproducer is included in `Silverback.Integration.Tests` as `SequenceBaseSemaphoreLeakTests` so the failure is visible even without the Coyote scaffolding.

## Test status

| Test | Status |
| --- | --- |
| `ConcurrentAbort_ShouldReachAbortedStateExactlyOnce` | passes |
| `ConcurrentErrorAborts_ShouldSetAbortExceptionExactlyOnce` | passes |
| `AbortThenAbortIfIncomplete_ShouldBothReturnAndRemainAborted` | **fails** (demonstrates bug) |
| `ConcurrentAbortMix_ShouldConvergeToSingleAbortedStateWithoutSemaphoreLeak` | **fails** (demonstrates bug) |
| `SequenceBaseSemaphoreLeakTests.AbortIfIncompleteAsync_AfterAbort_ShouldNotLeakCompleteSemaphore` (plain xunit) | **fails** (demonstrates bug) |

3 failing tests, all symptoms of the same one-line defect.

## Running locally

` ` `
dotnet tool install --global Microsoft.Coyote.CLI --version 1.7.11
dotnet test tests/Silverback.Tests.Concurrency/Silverback.Tests.Concurrency.csproj
` ` `

The `CoyoteRewrite` MSBuild target sets `DOTNET_ROLL_FORWARD=Major` because `Microsoft.Coyote.CLI` ships as `net8.0` and this solution targets `net10.0`.