### PR TITLE
test: repro ThreadPool starvation with sync batch subscribers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,8 @@
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.7.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.103" />
+    <PackageVersion Include="Microsoft.Coyote" Version="1.7.11" />
+    <PackageVersion Include="Microsoft.Coyote.Test" Version="1.7.11" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="10.0.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />

--- a/Silverback.sln
+++ b/Silverback.sln
@@ -130,6 +130,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Silverback.Storage.Relation
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Silverback.Tools.Generators.Docs.Headers", "tools\Silverback.Tools.Generators.Docs.Headers\Silverback.Tools.Generators.Docs.Headers.csproj", "{5AB6F39A-5B87-461D-9E6A-C2847016AC7D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Silverback.Tests.Concurrency", "tests\Silverback.Tests.Concurrency\Silverback.Tests.Concurrency.csproj", "{C07E10A1-CC00-4FFF-A0A0-000000000001}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -308,6 +310,10 @@ Global
 		{5AB6F39A-5B87-461D-9E6A-C2847016AC7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5AB6F39A-5B87-461D-9E6A-C2847016AC7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5AB6F39A-5B87-461D-9E6A-C2847016AC7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C07E10A1-CC00-4FFF-A0A0-000000000001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C07E10A1-CC00-4FFF-A0A0-000000000001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C07E10A1-CC00-4FFF-A0A0-000000000001}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C07E10A1-CC00-4FFF-A0A0-000000000001}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -342,6 +348,7 @@ Global
 		{5244CA89-97CA-418E-8976-357057A104F6} = {6AFB87A3-501B-4A87-B94C-205AEB118D97}
 		{9C26779F-D843-4B87-BCE5-ABC283E6A16B} = {6AFB87A3-501B-4A87-B94C-205AEB118D97}
 		{5AB6F39A-5B87-461D-9E6A-C2847016AC7D} = {9818A770-01ED-4340-BD4A-CFDDA6C56168}
+		{C07E10A1-CC00-4FFF-A0A0-000000000001} = {6AFB87A3-501B-4A87-B94C-205AEB118D97}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {89DA4AF5-B982-42AD-A829-8A72BCB21227}

--- a/src/Silverback.Core/Silverback.Core.csproj
+++ b/src/Silverback.Core/Silverback.Core.csproj
@@ -46,6 +46,9 @@
       <_Parameter1>Silverback.Integration.Tests</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Silverback.Tests.Concurrency</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Silverback.Integration.Tests.E2E</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/src/Silverback.Integration/Silverback.Integration.csproj
+++ b/src/Silverback.Integration/Silverback.Integration.csproj
@@ -31,6 +31,9 @@
       <_Parameter1>Silverback.Integration.Tests</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Silverback.Tests.Concurrency</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Silverback.Integration.Kafka</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/tests/Silverback.Integration.Tests.E2E/Kafka/BatchProcessingTests.ThreadPoolStarvation.cs
+++ b/tests/Silverback.Integration.Tests.E2E/Kafka/BatchProcessingTests.ThreadPoolStarvation.cs
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Silverback.Messaging.Broker;
+using Silverback.Messaging.Configuration;
+using Silverback.Tests.Integration.E2E.TestTypes.Messages;
+using Xunit;
+
+namespace Silverback.Tests.Integration.E2E.Kafka;
+
+public partial class BatchProcessingTests
+{
+    /// <summary>
+    ///     Demonstrates ThreadPool starvation when using synchronous IEnumerable subscribers
+    ///     with many partitions. Each partition's batch subscriber blocks a ThreadPool thread
+    ///     in SafeWait (MessageStreamEnumerable.GetEnumerable:149), eventually starving
+    ///     async continuations needed to push messages and drain channels.
+    /// </summary>
+    [Fact]
+    public async Task Batch_ShouldStarveThreadPool_WhenSyncEnumerableWithManyPartitions()
+    {
+        const int partitionCount = 24;
+        const int batchSize = 5;
+        const int messagesPerPartition = batchSize; // One full batch per partition
+        const int totalMessages = partitionCount * messagesPerPartition;
+
+        // Constrain the ThreadPool to simulate real-world conditions.
+        // The base class sets MinThreads = 4 * ProcessorCount to prevent starvation in other tests.
+        // Here we intentionally lower it to expose the bug.
+        ThreadPool.GetMinThreads(out int originalMinWorker, out int originalMinIo);
+        ThreadPool.SetMinThreads(4, 4); // Typical default on a 4-core machine
+
+        try
+        {
+            TestingCollection<List<TestEventOne>> receivedBatches = [];
+            int completedBatches = 0;
+
+            await Host.ConfigureServicesAndRunAsync(
+                services => services
+                    .AddLogging()
+                    .AddSilverback()
+                    .WithConnectionToMessageBroker(
+                        options => options
+                            .AddMockedKafka(mockOptions => mockOptions.WithDefaultPartitionsCount(partitionCount)))
+                    .AddKafkaClients(
+                        clients => clients
+                            .WithBootstrapServers("PLAINTEXT://e2e")
+                            .AddConsumer(
+                                consumer => consumer
+                                    .WithGroupId(DefaultGroupId)
+                                    .CommitOffsetEach(1)
+                                    .Consume<TestEventOne>(
+                                        endpoint => endpoint
+                                            .ConsumeFrom(DefaultTopicName)
+                                            .EnableBatchProcessing(batchSize))))
+                    .AddDelegateSubscriber<IEnumerable<TestEventOne>>(HandleBatch));
+
+            void HandleBatch(IEnumerable<TestEventOne> batch)
+            {
+                List<TestEventOne> list = [];
+                receivedBatches.Add(list);
+
+                foreach (TestEventOne message in batch)
+                {
+                    list.Add(message);
+                }
+
+                Interlocked.Increment(ref completedBatches);
+            }
+
+            // Produce messages distributed across all partitions via kafka key
+            IProducer producer = Helper.GetProducer(
+                producer => producer
+                    .WithBootstrapServers("PLAINTEXT://e2e")
+                    .Produce<TestEventOne>(
+                        endpoint => endpoint
+                            .ProduceTo(DefaultTopicName)
+                            .SetKafkaKey(envelope => envelope.Message?.ContentEventOne)));
+
+            for (int i = 0; i < totalMessages; i++)
+            {
+                // Use partition index as key to distribute evenly across all partitions
+                await producer.ProduceAsync(new TestEventOne { ContentEventOne = $"p{i % partitionCount}" });
+            }
+
+            // Wait for all messages to be consumed, with a short timeout.
+            // Under starvation this will time out because ThreadPool threads are all blocked
+            // in synchronous SafeWait and async continuations (PushAsync, channel drain) can't run.
+            bool allConsumed = false;
+            await AsyncTestingUtil.WaitAsync(
+                () => allConsumed = receivedBatches.Sum(batch => batch.Count) == totalMessages,
+                TimeSpan.FromSeconds(30));
+
+            // If all messages were consumed within the timeout, the system didn't starve
+            // (e.g., because the ThreadPool grew fast enough). This is the expected behavior
+            // when the fix is applied. If the test times out or not all messages are consumed,
+            // the starvation is confirmed.
+            if (!allConsumed)
+            {
+                int received = receivedBatches.Sum(batch => batch.Count);
+                int pending = totalMessages - received;
+                ThreadPool.GetAvailableThreads(out int availableWorker, out _);
+                ThreadPool.GetMaxThreads(out int maxWorker, out _);
+                ThreadPool.GetMinThreads(out int minWorker, out _);
+
+                throw new TimeoutException(
+                    $"ThreadPool starvation detected: only {received}/{totalMessages} messages consumed " +
+                    $"({completedBatches} batches completed) after 30s timeout. " +
+                    $"ThreadPool state: min={minWorker}, available={availableWorker}, max={maxWorker}. " +
+                    $"With {partitionCount} partitions and sync IEnumerable subscribers, " +
+                    $"{partitionCount} ThreadPool threads are permanently blocked in SafeWait " +
+                    $"at MessageStreamEnumerable.GetEnumerable(), starving async continuations. " +
+                    $"Pending messages: {pending}");
+            }
+        }
+        finally
+        {
+            // Restore the ThreadPool min threads for other tests
+            ThreadPool.SetMinThreads(originalMinWorker, originalMinIo);
+        }
+    }
+
+    /// <summary>
+    ///     Control test: same scenario with IAsyncEnumerable subscriber, which does NOT
+    ///     block ThreadPool threads. Should always succeed regardless of ThreadPool size.
+    /// </summary>
+    [Fact]
+    public async Task Batch_ShouldNotStarveThreadPool_WhenAsyncEnumerableWithManyPartitions()
+    {
+        const int partitionCount = 24;
+        const int batchSize = 5;
+        const int messagesPerPartition = batchSize;
+        const int totalMessages = partitionCount * messagesPerPartition;
+
+        ThreadPool.GetMinThreads(out int originalMinWorker, out int originalMinIo);
+        ThreadPool.SetMinThreads(4, 4);
+
+        try
+        {
+            TestingCollection<List<TestEventOne>> receivedBatches = [];
+            int completedBatches = 0;
+
+            await Host.ConfigureServicesAndRunAsync(
+                services => services
+                    .AddLogging()
+                    .AddSilverback()
+                    .WithConnectionToMessageBroker(
+                        options => options
+                            .AddMockedKafka(mockOptions => mockOptions.WithDefaultPartitionsCount(partitionCount)))
+                    .AddKafkaClients(
+                        clients => clients
+                            .WithBootstrapServers("PLAINTEXT://e2e")
+                            .AddConsumer(
+                                consumer => consumer
+                                    .WithGroupId(DefaultGroupId)
+                                    .CommitOffsetEach(1)
+                                    .Consume<TestEventOne>(
+                                        endpoint => endpoint
+                                            .ConsumeFrom(DefaultTopicName)
+                                            .EnableBatchProcessing(batchSize))))
+                    .AddDelegateSubscriber<IAsyncEnumerable<TestEventOne>>(HandleBatch));
+
+            async Task HandleBatch(IAsyncEnumerable<TestEventOne> batch)
+            {
+                List<TestEventOne> list = [];
+                receivedBatches.Add(list);
+
+                await foreach (TestEventOne message in batch)
+                {
+                    list.Add(message);
+                }
+
+                Interlocked.Increment(ref completedBatches);
+            }
+
+            IProducer producer = Helper.GetProducer(
+                producer => producer
+                    .WithBootstrapServers("PLAINTEXT://e2e")
+                    .Produce<TestEventOne>(
+                        endpoint => endpoint
+                            .ProduceTo(DefaultTopicName)
+                            .SetKafkaKey(envelope => envelope.Message?.ContentEventOne)));
+
+            for (int i = 0; i < totalMessages; i++)
+            {
+                await producer.ProduceAsync(new TestEventOne { ContentEventOne = $"p{i % partitionCount}" });
+            }
+
+            await AsyncTestingUtil.WaitAsync(
+                () => receivedBatches.Sum(batch => batch.Count) == totalMessages,
+                TimeSpan.FromSeconds(30));
+
+            receivedBatches.Sum(batch => batch.Count).ShouldBe(totalMessages);
+            completedBatches.ShouldBe(partitionCount);
+        }
+        finally
+        {
+            ThreadPool.SetMinThreads(originalMinWorker, originalMinIo);
+        }
+    }
+}

--- a/tests/Silverback.Integration.Tests/Messaging/Sequences/SequenceBaseSemaphoreLeakTests.cs
+++ b/tests/Silverback.Integration.Tests/Messaging/Sequences/SequenceBaseSemaphoreLeakTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System;
+using System.Threading.Tasks;
+using Shouldly;
+using Silverback.Messaging.Broker.Behaviors;
+using Silverback.Messaging.Sequences;
+using Silverback.Messaging.Sequences.Chunking;
+using Xunit;
+
+namespace Silverback.Tests.Integration.Messaging.Sequences;
+
+// Non-Coyote reproducer for a semaphore leak in SequenceBase<TEnvelope>.AbortIfIncompleteAsync.
+// When the sequence is already aborted (or completed), AbortIfIncompleteAsync acquires
+// _completeSemaphoreSlim and then early-returns on the !IsPending check without releasing
+// it. The leak only bites on the next synchronous wait on that semaphore, which happens
+// inside Dispose().
+public class SequenceBaseSemaphoreLeakTests
+{
+    [Fact]
+    public async Task AbortIfIncompleteAsync_AfterAbort_ShouldNotLeakCompleteSemaphore()
+    {
+        ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
+        ChunkSequence sequence = new("leak-test", 10, context);
+
+        await sequence.AbortAsync(SequenceAbortReason.IncompleteSequence);
+        sequence.IsAborted.ShouldBeTrue();
+
+        // This is the call that leaks: it acquires _completeSemaphoreSlim, sees !IsPending,
+        // and returns without releasing.
+        await sequence.AbortIfIncompleteAsync();
+
+        // Dispose() performs a synchronous Wait() on _completeSemaphoreSlim. If the semaphore
+        // is leaked it will block here forever; we wrap the call in Task.Run with a timeout so
+        // the test fails cleanly rather than hanging.
+        Task disposeTask = Task.Run(sequence.Dispose);
+        Task finished = await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromSeconds(5)));
+
+        finished.ShouldBe(disposeTask, "Dispose() blocked — AbortIfIncompleteAsync leaked _completeSemaphoreSlim.");
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/AUDIT-FOLLOWUPS.md
+++ b/tests/Silverback.Tests.Concurrency/AUDIT-FOLLOWUPS.md
@@ -1,0 +1,151 @@
+# Silverback Concurrency Audit — Follow-up Tests
+
+This file tracks audit findings that are not yet covered by a Coyote test in
+`tests/Silverback.Tests.Concurrency/`. It exists so reviewers can flip the
+failing tests / skipped tests into fixes one at a time without losing the audit
+context. Each entry points at the source location and describes what a proper
+test would look like.
+
+## Covered in this branch
+
+| # | Test file | Status |
+|---|---|---|
+| H1 | `SequenceStoreConcurrencyTests.cs` | **Failing** — catches `InvalidOperationException` from the Dictionary enumerator when `AddAsync` races with `GetEnumerator`. |
+| C2 | `MessageStreamProviderCoyoteTests.Abort_RacingCompleteAsync_ShouldNotReturnAsSilentNoOp` | **Failing** — catches `InvalidOperationException: "The streams are already completed"` thrown from `Abort()` when it races with `CompleteAsync()`. |
+| H4 | `MessageStreamProviderCoyoteTests.CreateStream_RacingPushAsync_...` | **Skipped** — the async enumerator path crashes the Coyote test host with an `AsyncTaskMethodBuilder.SetResult` double-set. Needs a non-enumerator driver. |
+| C1 | `SequenceAddCompleteRaceCoyoteTests.CompleteCoreAsync_RacingAbortAsync_...` | **Skipped** — scaffolding and reflection hook into `TestSequence` are in place. The default Coyote runner reports the race as a "potential deadlock" before reaching a concrete bug; the runner needs `WithPotentialDeadlocksReportedAsBugs(false)`, `WithConcurrencyFuzzingEnabled()`, `WithTestingIterations(10_000)`, and the invariant should assert downstream side effects on the `IConsumerTransactionManager` probe rather than terminal enum state. |
+
+## Not covered — tractable with modest harness work
+
+### H2 — `_sequences` iterated while mutated in `CompleteLinkedSequence`
+
+- **Loc:** `src/Silverback.Integration/Messaging/Sequences/SequenceBase`1.cs:181-185, 491-500`.
+- **State:** dormant — the only in-tree subclass that sets `trackIdentifiers: false`
+  (`UnboundedSequence`) never receives child sequences, so `CompleteLinkedSequence`'s
+  `_sequences?.Remove(sequence)` is never hit during a `ForEach` iteration.
+- **Test sketch:**
+  1. Create a `TestSequence` constructed with `trackIdentifiers: false` (add a ctor
+     overload; the production ctor accepts it).
+  2. Inject two child sequences into `_sequences` via reflection.
+  3. Invoke `((ISequenceImplementation)parent).NotifyProcessingCompleted()` and
+     assert no `InvalidOperationException` is thrown from the enumerator.
+- This is not inherently a concurrency bug; Coyote is overkill. A plain xunit
+  test would catch it just as well, once a `trackIdentifiers: false` subclass
+  with child sequences exists in production code.
+
+### H3 — `Dispose()` orders `_streamProvider.Dispose()` before draining pending adds
+
+- **Loc:** `SequenceBase`1.cs:447-480`.
+- **Current order:** `_streamProvider.Dispose()` → `_addCancellationTokenSource.Dispose()` →
+  `_sequences?.ForEach(s => s.Dispose())` → `_addSemaphoreSlim.Wait()` → `_completeSemaphoreSlim.Wait()`.
+- **Bug:** a concurrent `AddAsync` holding `_addSemaphoreSlim` may still be inside
+  `_streamProvider.PushAsync` when `_streamProvider.Dispose()` runs, so the push can
+  see a disposed provider and throw `ObjectDisposedException`.
+- **Test sketch:** requires a controllable subscriber that yields inside `PushAsync`.
+  The current drain-pattern crashes the Coyote test host (see H4). An alternative is
+  a fake `IMessageStreamProvider` that records a "push in flight" callback — but the
+  production `SequenceBase` only accepts `MessageStreamProvider<T>` (concrete class)
+  as a ctor param, so the fake would need to inherit from it, and a few of its members
+  are `internal sealed`. Tractable but not trivial.
+- **Fix direction:** acquire both semaphores first, then dispose.
+
+### C4 — `AddAsync` can observe `IsPending == true` after the stream provider has been completed
+
+- **Loc:** `SequenceBase`1.cs:525-546` (`CompleteCoreAsync`).
+- **Bug:** between `await _streamProvider.CompleteAsync(cancellationToken)` returning and
+  `_completeState = CompleteState.Complete` being assigned at the end of the method, a
+  concurrent `AddAsync` caller can still observe `IsPending == true` (because
+  `IsPending => _completeState == CompleteState.NotComplete`) and attempt to push into
+  an already-completed stream provider, which throws
+  `InvalidOperationException("The streams are already completed or aborted.")` from
+  `MessageStreamProvider`1.PushAsync:81`.
+- **Test sketch:** same subscriber problem as C1/H3. Can probably be collapsed into
+  the C1 harness once that one runs; C4 is essentially the symmetric observation.
+- **Fix direction:** move the `_completeState = Complete` assignment *before* the
+  `await _streamProvider.CompleteAsync`, or acquire `_completeSemaphoreSlim` around
+  the whole tail of `AddCoreAsync` (as in the C1 fix).
+
+## Not covered — requires substantial Kafka fake infrastructure
+
+### C3 — `ConsumerChannelsManager` releases `_messagesLimiterSemaphoreSlim` based on `CurrentCount`, not ownership
+
+- **Loc:** `src/Silverback.Integration.Kafka/Messaging/Broker/Kafka/ConsumerChannelsManager.cs:150-165`.
+- **Test sketch:** reproduce the pattern in isolation — a `SemaphoreSlim limiter = new(2, 2)`,
+  a helper method that mirrors the conditional-acquire / count-based-release pattern, and
+  a Coyote test that concurrently flips `_channels.Count` across the `MaxDegreeOfParallelism`
+  boundary. Either writes a mini fake of `ConsumerChannelsManager` (loses regression
+  protection) or mocks out enough of `IConsumer`, `IConsumerConfiguration`, `IConsumeLoopHandler`,
+  `IKafkaClientWrapper`, `ConsumerChannel<T>` to spin up the real class.
+- **Fix direction:** capture `bool acquired` locally and release iff true.
+
+### H5 — Kafka commit TOCTOU on revoked partitions
+
+- **Loc:** `src/Silverback.Integration.Kafka/Messaging/Broker/KafkaConsumer.cs:250-279` (`CommitCoreAsync`) and `152-174` (`OnPartitionsRevoked`).
+- **Test sketch:** needs a fake `IConfluentConsumerWrapper` recording `StoreOffset` calls and a
+  Coyote-controlled `_revokedPartitions` mutation. Moderate infrastructure investment.
+
+### H6 — `OnPartitionsRevoked` commits after `FireAndForget` consume-loop stop
+
+- **Loc:** `KafkaConsumer.cs:152-174`.
+- **Test sketch:** same fake as H5. Model `StopAsync` as a task that only completes when the
+  test releases a gate; assert `Client.Commit()` is not called before that.
+
+### H7 — `ConsumeLoopHandler.Start/Stop` racy on non-volatile `IsConsuming`
+
+- **Loc:** `src/Silverback.Integration.Kafka/Messaging/Broker/Kafka/ConsumeLoopHandler.cs:54-102`.
+- **Test sketch:** race two `Start()` callers and assert only one consume-loop task runs. Requires
+  mocking `IConfluentConsumerWrapper` and friends. Lower-value than C1/C2/C3.
+
+## Not covered — low value under Coyote
+
+### M1 — `ConsumerChannel.Reset` non-atomic channel reassignment
+
+- **Loc:** `src/Silverback.Integration/Messaging/Broker/ConsumerChannel`1.cs:76-84`.
+- Works today because callers await stop-then-reset. Document the precondition with an XML
+  comment on `Reset`; regression-test via a plain unit test if someone adds a caller that
+  violates the precondition.
+
+### M2 — `OffsetsTracker.TrackOffset` two non-atomic `AddOrUpdate` calls
+
+- **Loc:** `src/Silverback.Integration.Kafka/Messaging/Broker/Kafka/OffsetsTracker.cs:27-42, 70-79`.
+- A test would compose a reader that sees `rollback > commit + 1`. Straightforward with Coyote
+  once you have the concrete dictionaries; deferred because the observable bug is subtle and
+  only matters at rebalance time.
+
+### M3 — `SequenceBase._completeState` non-volatile int
+
+- **Loc:** `SequenceBase`1.cs:47, 556-573`.
+- Timer loop reads the non-volatile field. On ARM64 the timer may lag observing the new
+  state for longer than intended. The fix is `Volatile.Read` or marking the field volatile.
+  Under Coyote on x64 this will probably never reproduce because x64 has a stronger memory
+  model.
+
+### L1 — `AbortCoreAsync` unconditional `_completeState = Aborted` write
+
+- Subsumed by C1; will be fixed as part of the C1 fix.
+
+### L2 — `AsyncEvent<TArg>.InvokeAsync` runs handlers synchronously under a `System.Threading.Lock`
+
+- **Loc:** `src/Silverback.Core/AsyncEvent`1.cs:68-79`.
+- Not a correctness bug — `System.Threading.Lock` is reentrant on net9+. Noted in the audit
+  for completeness; no test warranted.
+
+## Harness notes
+
+Three structural issues surfaced while writing this batch. Each affects more than one test:
+
+1. **`MessageStreamEnumerable<T>` async enumerator vs Coyote rewriter.** The
+   `await foreach` pattern against a rewritten `IMessageStreamEnumerable<T>` crashes the
+   Coyote test host with `AsyncTaskMethodBuilder.SetResult` being called twice. Needs an
+   alternative subscriber driver (e.g. a direct `IAsyncEnumerator<T>` loop with manual
+   `MoveNextAsync`, or an in-memory fake of `ILazyMessageStreamEnumerable` that bypasses
+   the state machine entirely). Affects H3, H4, C1, C4.
+2. **Coyote's "potential deadlock" heuristic triggers on legitimate lock inversions that
+   eventually terminate.** The C1 race is a real inversion, but the terminating schedule
+   (T1's `provider.CompleteAsync` throws "already aborted" once T2's `AbortIfPending`
+   ran first, T1 releases the add semaphore via its finally, T2 proceeds) is dismissed
+   as a suspected hang. Use `Configuration.WithPotentialDeadlocksReportedAsBugs(false)`
+   plus `WithDeadlockTimeout(...)` and `WithConcurrencyFuzzingEnabled()`.
+3. **NSubstitute mocks show up as "uncontrolled invocations".** Coyote's scheduler cannot
+   instrument them, but this is cosmetic: the tests still find bugs. If we want cleaner
+   output, replace NSubstitute with hand-rolled fakes in the Coyote-sensitive test paths.

--- a/tests/Silverback.Tests.Concurrency/ConsumerChannelsSemaphoreCoyoteTests.cs
+++ b/tests/Silverback.Tests.Concurrency/ConsumerChannelsSemaphoreCoyoteTests.cs
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System.Threading;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Silverback.Tests.Concurrency;
+
+// Audit finding C3 — ConsumerChannelsManager releases _messagesLimiterSemaphoreSlim based
+// on CurrentCount, not ownership.
+//
+// src/Silverback.Integration.Kafka/Messaging/Broker/Kafka/ConsumerChannelsManager.cs:150-165:
+//
+//   if (_channels.Count > _consumer.Configuration.MaxDegreeOfParallelism)
+//       await _messagesLimiterSemaphoreSlim.WaitAsync(...);  // conditional acquire
+//   try { await _consumer.HandleMessageAsync(...); }
+//   finally
+//   {
+//       if (_messagesLimiterSemaphoreSlim.CurrentCount < _consumer.Configuration.MaxDegreeOfParallelism)
+//           _messagesLimiterSemaphoreSlim.Release();          // condition != "did I acquire"
+//   }
+//
+// The interleaving that triggers the bug:
+//   1. T1, T2: acquire tokens (channelCount > maxDoP). Semaphore count = 0.
+//   2. Partition revoke: channelCount drops to <= maxDoP.
+//   3. T3: enters with channelCount <= maxDoP, skips acquire. Finishes. Finally sees
+//      CurrentCount=0 < maxDoP → releases a token it never owned. Count = 1.
+//   4. Partition reassignment: channelCount goes back above maxDoP.
+//   5. T4: acquires the extra token. Now T1, T2, T4 are all active simultaneously.
+//      Active count = 3 > maxDoP = 2. The limiter failed to limit.
+//
+// Over time, after many revoke/assign cycles, the leaked tokens accumulate in the
+// opposite direction too (under-release), eventually starving all message processing.
+// This matches the reported bug: "stops consuming after several thousand messages"
+// with 24 partitions.
+//
+// The test tracks peak concurrent active handlers and asserts it never exceeds maxDoP.
+//
+// Fix direction: capture `bool acquired` locally and release iff true.
+public class ConsumerChannelsSemaphoreCoyoteTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public ConsumerChannelsSemaphoreCoyoteTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void SemaphoreCurrentCountRelease_ShouldNotExceedMaxDoP_AfterChannelCountDrop()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                const int maxDoP = 2;
+                SemaphoreSlim limiter = new(maxDoP, maxDoP);
+                int channelCount = 4;
+
+                int active = 0;
+                int maxObservedActive = 0;
+
+                // Gate: holds T1/T2 mid-processing so they occupy their semaphore tokens
+                // while T3 enters, exits, and over-releases.
+                SemaphoreSlim gate = new(0, 4);
+
+                async Task ProcessHeld()
+                {
+                    if (channelCount > maxDoP)
+                        await limiter.WaitAsync().ConfigureAwait(false);
+
+                    try
+                    {
+                        InterlockedMax(ref maxObservedActive, Interlocked.Increment(ref active));
+                        await gate.WaitAsync().ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        Interlocked.Decrement(ref active);
+                        if (limiter.CurrentCount < maxDoP)
+                            limiter.Release();
+                    }
+                }
+
+                async Task ProcessQuick()
+                {
+                    if (channelCount > maxDoP)
+                        await limiter.WaitAsync().ConfigureAwait(false);
+
+                    try
+                    {
+                        InterlockedMax(ref maxObservedActive, Interlocked.Increment(ref active));
+                        await Task.Yield();
+                    }
+                    finally
+                    {
+                        Interlocked.Decrement(ref active);
+                        if (limiter.CurrentCount < maxDoP)
+                            limiter.Release();
+                    }
+                }
+
+                // Phase 1: T1, T2 acquire tokens and hold via gate.
+                // Semaphore count: 2 → 1 → 0. active = 2.
+                Task t1 = Task.Run(ProcessHeld);
+                Task t2 = Task.Run(ProcessHeld);
+                await Task.Yield();
+                await Task.Yield();
+
+                // Partition revoke: channels drop to <= maxDoP.
+                channelCount = 2;
+
+                // T3: enters, skips acquire (2 > 2 = false). Finishes quickly.
+                // T3 finally: CurrentCount = 0 < 2 → releases a token it never owned!
+                // Count: 0 → 1. active briefly 3 (T1 + T2 + T3), then back to 2.
+                Task t3 = Task.Run(ProcessQuick);
+                await t3.ConfigureAwait(false);
+
+                // Partition reassignment: channels go back up.
+                channelCount = 4;
+
+                // T4: acquires the over-released token. Count: 1 → 0.
+                // Now T1, T2, T4 are all active inside the try block.
+                // active = 3, which exceeds maxDoP = 2.
+                Task t4 = Task.Run(ProcessHeld);
+                await Task.Yield();
+                await Task.Yield();
+
+                // Release everyone
+                gate.Release(4);
+                await Task.WhenAll(t1, t2, t4).ConfigureAwait(false);
+
+                // Invariant: the semaphore should have prevented more than maxDoP
+                // concurrent active handlers at any point.
+                maxObservedActive.ShouldBeLessThanOrEqualTo(
+                    maxDoP,
+                    $"Peak concurrent active handlers was {maxObservedActive}, exceeding maxDoP={maxDoP}. " +
+                    "The CurrentCount-based release in ConsumerChannelsManager over-released a token " +
+                    "that was never acquired (after a channel-count drop), allowing more concurrent " +
+                    "processing than the limiter should permit. See audit C3.");
+            },
+            _output);
+    }
+
+    private static void InterlockedMax(ref int location, int value)
+    {
+        int current;
+        do
+        {
+            current = Volatile.Read(ref location);
+        }
+        while (value > current && Interlocked.CompareExchange(ref location, value, current) != current);
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/CoyoteTestRunner.cs
+++ b/tests/Silverback.Tests.Concurrency/CoyoteTestRunner.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Coyote.SystematicTesting;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+using CoyoteConfiguration = Microsoft.Coyote.Configuration;
+
+namespace Silverback.Tests.Concurrency;
+
+// Shared helper that runs an async test body under the Microsoft.Coyote systematic testing
+// engine. Each test class takes an ITestOutputHelper and forwards it here so Coyote's report
+// and any bug traces land in the xunit test output.
+//
+// The test assemblies (Silverback.Core, Silverback.Integration, and this test DLL) are
+// binary-rewritten by `coyote rewrite` as a post-build step in the .csproj so that async
+// state machines, SemaphoreSlim, Task.Run, etc. are intercepted by Coyote's scheduler.
+internal static class CoyoteTestRunner
+{
+    // Default iteration count for most tests. Raise to 10k+ (and pass explicitly) for races
+    // that require aggressive scheduling exploration to reproduce.
+    public const int DefaultIterations = 100;
+
+    public static void Run(Func<Task> testBody, ITestOutputHelper output, int iterations = DefaultIterations)
+    {
+        CoyoteConfiguration config = CoyoteConfiguration.Create()
+            .WithTestingIterations((uint)iterations)
+            .WithVerbosityEnabled()
+            .WithConsoleLoggingEnabled();
+
+        TestingEngine engine = TestingEngine.Create(config, testBody);
+        engine.Run();
+
+        string report = engine.GetReport();
+        output.WriteLine(report);
+
+        if (engine.TestReport.NumOfFoundBugs > 0)
+        {
+            string bugReports = string.Join("\n---\n", engine.TestReport.BugReports);
+            output.WriteLine("Bug reports:");
+            output.WriteLine(bugReports);
+            throw new XunitException(
+                $"Coyote found {engine.TestReport.NumOfFoundBugs} bug(s) across {iterations} iterations.\n\n{report}\n\nBug reports:\n{bugReports}");
+        }
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/KafkaConcurrencyPatternCoyoteTests.cs
+++ b/tests/Silverback.Tests.Concurrency/KafkaConcurrencyPatternCoyoteTests.cs
@@ -1,0 +1,334 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using Shouldly;
+using Silverback.Messaging.Broker;
+using Silverback.Messaging.Broker.Kafka;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Silverback.Tests.Concurrency;
+
+// Kafka-specific concurrency tests targeting audit findings H5, H6, H7, and M2.
+//
+// H5, H6, and H7 are pattern-level tests: they extract the production code's
+// synchronization pattern into standalone code that Coyote can schedule, rather
+// than constructing the full KafkaConsumer / ConsumeLoopHandler with all their
+// dependencies. This means the tests document and catch the BUG PATTERN but do
+// not regression-protect the exact production class. When the pattern is fixed
+// in production, these tests should be updated to mirror the new pattern.
+//
+// M2 tests the real OffsetsTracker class (public, zero dependencies).
+public class KafkaConcurrencyPatternCoyoteTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public KafkaConcurrencyPatternCoyoteTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    // H5 — Kafka commit TOCTOU on revoked partitions.
+    //
+    // KafkaConsumer.CommitCoreAsync (lines 251-279) filters offsets by IsNotRevoked
+    // using a LINQ Where, then double-checks IsNotRevoked inside the loop body.
+    // Both checks read _revokedPartitions (ConcurrentDictionary) which is concurrently
+    // mutated by OnPartitionsRevoked from the rebalance callback thread.
+    //
+    // The TOCTOU window: a partition passes both checks, then gets revoked before
+    // StoreOffset runs. The stored offset is for a partition the consumer no longer
+    // owns, which violates exactly-once semantics.
+    //
+    // The test models the pattern: an enumerable filtered by "not revoked", a loop
+    // body that re-checks "not revoked" then stores, and a concurrent revoke task
+    // that adds to the revoked set. If Coyote interleaves the revoke between the
+    // inner check and the store, the invariant fires.
+    [Fact]
+    public void CommitCoreAsync_RevokeRacingCommit_ShouldNotStoreOffsetForRevokedPartition()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                ConcurrentDictionary<TopicPartition, byte> revokedPartitions = new();
+                TopicPartition tp0 = new("topic", new Partition(0));
+                TopicPartition tp1 = new("topic", new Partition(1));
+
+                List<TopicPartition> allPartitions = [tp0, tp1];
+                ConcurrentBag<TopicPartition> storedOffsets = new();
+
+                // T1: commit path — mirrors CommitCoreAsync lines 258-275
+                Task commit = Task.Run(
+                    async () =>
+                    {
+                        IEnumerable<TopicPartition> filtered = allPartitions
+                            .Where(tp => !revokedPartitions.ContainsKey(tp));
+
+                        foreach (TopicPartition tp in filtered)
+                        {
+                            await Task.Yield(); // scheduling point for Coyote
+
+                            if (!revokedPartitions.ContainsKey(tp)) // inner check (still TOCTOU)
+                            {
+                                await Task.Yield(); // one more point between check and store
+                                storedOffsets.Add(tp); // mirrors StoreOffset(...)
+                            }
+                        }
+                    });
+
+                // T2: revoke path — mirrors OnPartitionsRevoked adding to _revokedPartitions
+                Task revoke = Task.Run(
+                    async () =>
+                    {
+                        await Task.Yield();
+                        revokedPartitions.TryAdd(tp1, 0);
+                    });
+
+                await Task.WhenAll(commit, revoke).ConfigureAwait(false);
+
+                // Invariant: no stored offset should be for a partition that is now revoked.
+                foreach (TopicPartition stored in storedOffsets)
+                {
+                    revokedPartitions.ContainsKey(stored).ShouldBeFalse(
+                        $"Stored offset for revoked partition {stored}. " +
+                        "The TOCTOU window between IsNotRevoked check and StoreOffset " +
+                        "allowed a commit for a partition the consumer no longer owns. " +
+                        "See audit H5.");
+                }
+            },
+            _output);
+    }
+
+    // H6 — OnPartitionsRevoked commits after fire-and-forget consume-loop stop.
+    //
+    // KafkaConsumer.OnPartitionsRevoked (lines 152-174):
+    //   _consumeLoopHandler.StopAsync().FireAndForget();  // does NOT await
+    //   Task.WhenAll(...StopReadingAsync...).SafeWait();
+    //   if (!Configuration.EnableAutoCommit)
+    //       Client.Commit();
+    //
+    // The consume loop keeps running after StopAsync is fired-and-forgotten. It may
+    // consume and write messages into channels between the moment StopAsync is triggered
+    // and the moment Client.Commit() runs. Those messages are included in the committed
+    // offsets but were never fully processed, violating exactly-once semantics.
+    //
+    // The test models the pattern: a "stop" task that takes time to complete, a "commit"
+    // that runs before the stop finishes, and a "consume" task that produces work items
+    // in between. Assert: no work item is produced after commit.
+    [Fact]
+    public void OnPartitionsRevoked_CommitBeforeStopCompletes_ShouldNotCommitUnprocessedMessages()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                ConcurrentBag<string> consumed = new();
+                ConcurrentBag<string> committed = new();
+                SemaphoreSlim stopGate = new(0, 1);
+                bool stopRequested = false;
+                bool commitDone = false;
+
+                // Consume loop: keeps producing until stopped
+                Task consumeLoop = Task.Run(
+                    async () =>
+                    {
+                        int i = 0;
+                        while (!stopRequested)
+                        {
+                            consumed.Add($"msg-{i++}");
+                            await Task.Yield();
+                        }
+
+                        // The real consume loop doesn't stop instantly; it may
+                        // produce one more message after the flag is set.
+                        consumed.Add($"msg-{i}-after-stop");
+                    });
+
+                // Revoke handler pattern
+                Task revokeHandler = Task.Run(
+                    async () =>
+                    {
+                        // Fire-and-forget stop
+                        Task stopTask = Task.Run(
+                            async () =>
+                            {
+                                await stopGate.WaitAsync().ConfigureAwait(false);
+                                stopRequested = true;
+                            });
+                        // Do NOT await stopTask — fire and forget
+
+                        await Task.Yield(); // simulates StopReadingAsync().SafeWait()
+
+                        // Commit: snapshot whatever consumed is the "committed position"
+                        foreach (string msg in consumed)
+                        {
+                            committed.Add(msg);
+                        }
+
+                        commitDone = true;
+
+                        // Now release the stop gate so the consume loop eventually ends
+                        stopGate.Release();
+                        await stopTask.ConfigureAwait(false);
+                    });
+
+                await Task.WhenAll(consumeLoop, revokeHandler).ConfigureAwait(false);
+
+                // Invariant: everything committed should have been consumed BEFORE commit.
+                // Messages consumed AFTER commit are lost (committed offsets advanced past them
+                // but they were never processed).
+                // In this simplified model, the committed set was snapshotted from consumed,
+                // so the committed messages are a subset of consumed. But the consume loop may
+                // have added MORE messages after the snapshot, and those messages are "lost"
+                // because the committed offsets would include the produce-loop's latest position.
+                //
+                // The test checks: did the consume loop produce any message after commitDone
+                // was set? If so, the fire-and-forget pattern is unsound.
+                int consumedAfterCommit = consumed.Count - committed.Count;
+                consumedAfterCommit.ShouldBe(
+                    0,
+                    $"Consumed {consumedAfterCommit} message(s) after commit ran. " +
+                    "OnPartitionsRevoked fires StopAsync but does not await it, " +
+                    "then calls Client.Commit(). Messages consumed between the " +
+                    "fire-and-forget and the commit are included in the committed " +
+                    "offset position but were never fully processed. " +
+                    "See audit H6.");
+            },
+            _output);
+    }
+
+    // H7 — ConsumeLoopHandler.Start/Stop racy on non-volatile IsConsuming.
+    //
+    // ConsumeLoopHandler.Start() (lines 54-81):
+    //   if (IsConsuming) return;    // non-volatile read
+    //   IsConsuming = true;
+    //   Task.Factory.StartNew(...ConsumeAsync...).FireAndForget();
+    //
+    // Two concurrent Start() callers can both read IsConsuming=false and both
+    // start a consume loop. Two loops consuming from the same Confluent consumer
+    // causes undefined behavior (double-poll, offset confusion).
+    [Fact]
+    public void ConsumeLoopHandlerStart_ConcurrentCalls_ShouldStartExactlyOneLoop()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                bool isConsuming = false;
+                int loopsStarted = 0;
+
+                Task Start()
+                {
+                    // Mirrors ConsumeLoopHandler.Start() lines 58-81
+                    if (isConsuming)
+                        return Task.CompletedTask;
+
+                    isConsuming = true;
+
+                    Interlocked.Increment(ref loopsStarted);
+
+                    // Simulate Task.Factory.StartNew(ConsumeAsync).FireAndForget()
+                    Task.Run(
+                        async () =>
+                        {
+                            await Task.Yield(); // simulates the consume loop body
+                        }).FireAndForget();
+
+                    return Task.CompletedTask;
+                }
+
+                Task t1 = Task.Run(Start);
+                Task t2 = Task.Run(Start);
+
+                await Task.WhenAll(t1, t2).ConfigureAwait(false);
+                await Task.Yield(); // let fire-and-forget loops settle
+
+                loopsStarted.ShouldBe(
+                    1,
+                    $"Started {loopsStarted} consume loops instead of 1. " +
+                    "Two concurrent Start() calls both read IsConsuming=false " +
+                    "(non-volatile bool) and both started a loop. " +
+                    "See audit H7.");
+            },
+            _output);
+    }
+
+    // M2 — OffsetsTracker.TrackOffset performs two non-atomic AddOrUpdates.
+    //
+    // OffsetsTracker.TrackOffset (lines 27-42) updates _commitOffsets and
+    // _rollbackOffsets in two separate AddOrUpdate calls. A concurrent reader
+    // calling GetCommitOffsets() + GetRollbackOffsets() can observe a state
+    // where one dict has been updated but the other hasn't yet.
+    //
+    // The test writes offsets from one task while reading from another and
+    // checks that every partition visible in rollback offsets is also visible
+    // in commit offsets (they should always appear as a pair since TrackOffset
+    // writes both).
+    [Fact]
+    public void OffsetsTracker_ConcurrentTrackAndRead_ShouldNotObservePartialState()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                OffsetsTracker tracker = new();
+                TopicPartition tp = new("topic", new Partition(0));
+                bool observedPartialState = false;
+
+                // T1: repeatedly track offsets
+                Task writer = Task.Run(
+                    async () =>
+                    {
+                        for (int i = 0; i < 10; i++)
+                        {
+                            tracker.TrackOffset(new KafkaOffset(tp, new Offset(i)));
+                            await Task.Yield();
+                        }
+                    });
+
+                // T2: repeatedly read both dicts and check consistency
+                Task reader = Task.Run(
+                    async () =>
+                    {
+                        for (int i = 0; i < 10; i++)
+                        {
+                            var commits = tracker.GetCommitOffsets();
+                            await Task.Yield(); // scheduling point between the two reads
+                            var rollbacks = tracker.GetRollbackOffSets();
+
+                            // If rollbacks has a key that commits doesn't, the reader
+                            // observed a partial state (second AddOrUpdate ran before first).
+                            // Vice versa is also partial but less likely to cause issues.
+                            foreach (KafkaOffset rb in rollbacks)
+                            {
+                                if (!commits.Any(c => c.TopicPartition == rb.TopicPartition))
+                                {
+                                    observedPartialState = true;
+                                }
+                            }
+
+                            await Task.Yield();
+                        }
+                    });
+
+                await Task.WhenAll(writer, reader).ConfigureAwait(false);
+
+                observedPartialState.ShouldBeFalse(
+                    "Reader observed a partition in rollback offsets that was absent from " +
+                    "commit offsets. OffsetsTracker.TrackOffset performs two sequential " +
+                    "AddOrUpdate calls that are not atomic as a pair. " +
+                    "See audit M2.");
+            },
+            _output);
+    }
+}
+
+// Minimal extension to mirror Silverback.Util.TaskExtensions.FireAndForget,
+// which is internal. The Coyote rewriter intercepts Task.Run and scheduling;
+// the extension itself just suppresses the compiler warning.
+file static class FireAndForgetExtensions
+{
+    public static void FireAndForget(this Task task) => _ = task;
+}

--- a/tests/Silverback.Tests.Concurrency/MessageStreamProviderCoyoteTests.cs
+++ b/tests/Silverback.Tests.Concurrency/MessageStreamProviderCoyoteTests.cs
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System.Reflection;
+using System.Threading.Tasks;
+using Shouldly;
+using Silverback.Messaging.Messages;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Silverback.Tests.Concurrency;
+
+// Audit findings C2 and H4 — both rooted in MessageStreamProvider<T>.
+//
+// C2: Abort() and CompleteAsync() are not safe to call concurrently. The audit
+//     predicted a silent no-op via the early-return guard
+//         if (_isAborting || _isCompleting) return;
+//     but there is also a second, orthogonal failure mode: once CompleteAsync
+//     has finished and `_completed = true`, a subsequent Abort() reaches the
+//     line `if (_completed) throw new InvalidOperationException(...)` and
+//     throws. Both manifestations violate the invariant "Abort() called
+//     concurrently with an in-flight CompleteAsync() must either wait for
+//     the complete then observe the completed state, or actually abort the
+//     streams; it must never silently no-op and must never throw." Coyote
+//     catches whichever manifestation its scheduler hits first — in this
+//     repo it lands on the throw variant within a few iterations.
+//
+// H4: _lazyStreams is added to under `lock (_lazyStreams)` but read without
+//     the lock in StreamsCount, Abort, CompleteAsync, and PushToCompatibleStreams.
+//     Racing CreateStream() against PushAsync() can therefore either throw
+//     from the enumerator version check or silently drop the newly added
+//     stream from a push.
+//
+// Both tests currently fail on master. Fix directions tracked in the audit;
+// broadly: replace the re-entry guard in Abort/CompleteAsync with a proper
+// wait-then-observe pattern, and read _lazyStreams only under the lock (or
+// switch to a ConcurrentBag/ImmutableArray<T>).
+public class MessageStreamProviderCoyoteTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public MessageStreamProviderCoyoteTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    // C2
+    [Fact]
+    public void Abort_RacingCompleteAsync_ShouldNotReturnAsSilentNoOp()
+    {
+        // Race CompleteAsync() against Abort() on an otherwise-idle MessageStreamProvider.
+        // The provider has no lazy streams, so CompleteAsync's ParallelForEachAsync body is
+        // essentially empty, but the method still runs through its guard:
+        //
+        //   1. early-return if (_isCompleting || _isAborting) return;
+        //   2. await _completeSemaphore.WaitAsync(cancellationToken);
+        //   3. try { ... _isCompleting = true; ... _completed = true; }
+        //      finally { _isCompleting = false; _completeSemaphore.Release(); }
+        //
+        // The symmetric Abort() has the same guard. If Coyote interleaves Abort() between
+        // steps 3's `_isCompleting = true` and the finally's reset, Abort falls into the
+        // early-return and silently no-ops: neither `_aborted` nor `_completed` is true
+        // at the moment Abort returns, even though the caller explicitly asked to abort.
+        //
+        // We snapshot the private `_aborted` / `_completed` fields via reflection immediately
+        // after Abort returns and assert that at least one of them is true. Reflection is
+        // used because the fields are `private`; `InternalsVisibleTo` only opens `internal`.
+        //
+        // Currently fails on master. Fix direction (audit C2): replace the re-entry guard
+        // with a proper wait-then-observe pattern so a losing racer either waits for the
+        // in-progress operation or actually performs its work.
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                MessageStreamProvider<string> provider = new();
+
+                Task producer = Task.Run(
+                    async () => await provider.CompleteAsync().ConfigureAwait(false));
+
+                bool abortObservedTerminalState = true;
+                Task aborter = Task.Run(
+                    () =>
+                    {
+                        provider.Abort();
+                        abortObservedTerminalState = ReadTerminalFlags(provider);
+                    });
+
+                await Task.WhenAll(producer, aborter).ConfigureAwait(false);
+
+                abortObservedTerminalState.ShouldBeTrue(
+                    "MessageStreamProvider.Abort() returned while _isCompleting was set, " +
+                    "leaving the provider in neither _aborted nor _completed state. " +
+                    "Caller asked to abort but Abort silently no-opped on cross-thread reentry. " +
+                    "See audit finding C2.");
+            },
+            _output);
+    }
+
+    private static bool ReadTerminalFlags(MessageStreamProvider<string> provider)
+    {
+        System.Type type = typeof(MessageStreamProvider<string>);
+        bool aborted = (bool)type
+            .GetField("_aborted", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(provider)!;
+        bool completed = (bool)type
+            .GetField("_completed", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(provider)!;
+        return aborted || completed;
+    }
+
+    // H4 — deferred for this batch. The enumerator path inside MessageStreamEnumerable<T>
+    // interacts with Coyote's rewritten AsyncTaskMethodBuilder in a way that crashes the
+    // test host (double SetResult). Needs investigation. Left as [Fact(Skip=...)] so it
+    // shows up in the report; un-skip once the rewriter interaction is understood or the
+    // test is restructured to avoid await foreach.
+    [Fact(Skip = "Coyote rewriter interaction with MessageStreamEnumerable async enumerator; see audit H4 follow-up")]
+    public void CreateStream_RacingPushAsync_ShouldNeitherThrowNorDropTheNewStream()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                MessageStreamProvider<string> provider = new();
+
+                // Pre-create one stream so _lazyStreams starts non-empty and PushToCompatibleStreams
+                // actually iterates something.
+                IMessageStreamEnumerable<string> first = provider.CreateStream<string>();
+                Task drainFirst = Task.Run(
+                    async () =>
+                    {
+                        try
+                        {
+                            await foreach (string msg in first.ConfigureAwait(false))
+                            {
+                                _ = msg;
+                                await Task.Yield();
+                            }
+                        }
+                        catch
+                        {
+                            // swallow abort/complete exceptions
+                        }
+                    });
+
+                // T1: keep pushing while T2 adds a second stream.
+                Task pushing = Task.Run(
+                    async () => await provider.PushAsync("msg").ConfigureAwait(false));
+
+                IMessageStreamEnumerable<string>? second = null;
+                Task adding = Task.Run(
+                    () =>
+                    {
+                        second = provider.CreateStream<string>();
+                    });
+
+                await Task.WhenAll(pushing, adding).ConfigureAwait(false);
+
+                // Cleanly tear down so drainFirst completes.
+                await provider.CompleteAsync().ConfigureAwait(false);
+                await drainFirst.ConfigureAwait(false);
+
+                second.ShouldNotBeNull();
+            },
+            _output);
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/SequenceAbortCoyoteTests.cs
+++ b/tests/Silverback.Tests.Concurrency/SequenceAbortCoyoteTests.cs
@@ -3,13 +3,11 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.Coyote.SystematicTesting;
 using Shouldly;
 using Silverback.Messaging.Broker.Behaviors;
 using Silverback.Messaging.Sequences;
 using Xunit;
 using Xunit.Abstractions;
-using CoyoteConfiguration = Microsoft.Coyote.Configuration;
 
 namespace Silverback.Tests.Concurrency;
 
@@ -36,7 +34,7 @@ public class SequenceAbortCoyoteTests
     [Fact]
     public void ConcurrentAbort_ShouldReachAbortedStateExactlyOnce()
     {
-        RunCoyoteTest(
+        CoyoteTestRunner.Run(
             async () =>
             {
                 ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
@@ -54,13 +52,14 @@ public class SequenceAbortCoyoteTests
                 sequence.IsAborted.ShouldBeTrue();
                 sequence.IsPending.ShouldBeFalse();
                 sequence.AbortReason.ShouldBe(SequenceAbortReason.IncompleteSequence);
-            });
+            },
+            _output);
     }
 
     [Fact]
     public void AbortThenAbortIfIncomplete_ShouldBothReturnAndRemainAborted()
     {
-        RunCoyoteTest(
+        CoyoteTestRunner.Run(
             async () =>
             {
                 ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
@@ -77,7 +76,8 @@ public class SequenceAbortCoyoteTests
                 sequence.IsAborted.ShouldBeTrue();
                 sequence.IsPending.ShouldBeFalse();
                 sequence.AbortReason.ShouldBe(SequenceAbortReason.Error);
-            });
+            },
+            _output);
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class SequenceAbortCoyoteTests
         // This mixes the two code paths that both take _completeSemaphoreSlim, so any
         // release-path asymmetry (such as the bug we found and fixed in AbortIfIncompleteAsync)
         // will manifest as either a deadlock or a stuck semaphore that Dispose() then hits.
-        RunCoyoteTest(
+        CoyoteTestRunner.Run(
             async () =>
             {
                 ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
@@ -102,7 +102,8 @@ public class SequenceAbortCoyoteTests
                 sequence.IsAborted.ShouldBeTrue();
                 sequence.IsPending.ShouldBeFalse();
                 sequence.AbortReason.ShouldBe(SequenceAbortReason.IncompleteSequence);
-            });
+            },
+            _output);
     }
 
     [Fact]
@@ -112,7 +113,7 @@ public class SequenceAbortCoyoteTests
         // should set AbortException; the second should observe IsAborted, wait on
         // _abortingTaskCompletionSource, and return. AbortException must be exactly one of the two
         // exceptions we passed in — no null, no partial state.
-        RunCoyoteTest(
+        CoyoteTestRunner.Run(
             async () =>
             {
                 ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
@@ -132,29 +133,7 @@ public class SequenceAbortCoyoteTests
                 Exception abortException = sequence.AbortException;
                 (abortException == ex1 || abortException == ex2).ShouldBeTrue(
                     "AbortException must be one of the exceptions that was passed in, not a wrapper or null.");
-            });
-    }
-
-    private void RunCoyoteTest(Func<Task> testBody, int iterations = 100)
-    {
-        CoyoteConfiguration config = CoyoteConfiguration.Create()
-            .WithTestingIterations((uint)iterations)
-            .WithVerbosityEnabled()
-            .WithConsoleLoggingEnabled();
-
-        TestingEngine engine = TestingEngine.Create(config, testBody);
-        engine.Run();
-
-        string report = engine.GetReport();
-        _output.WriteLine(report);
-
-        if (engine.TestReport.NumOfFoundBugs > 0)
-        {
-            string bugReports = string.Join("\n---\n", engine.TestReport.BugReports);
-            _output.WriteLine("Bug reports:");
-            _output.WriteLine(bugReports);
-            throw new Xunit.Sdk.XunitException(
-                $"Coyote found {engine.TestReport.NumOfFoundBugs} bug(s) across {iterations} iterations.\n\n{report}\n\nBug reports:\n{bugReports}");
-        }
+            },
+            _output);
     }
 }

--- a/tests/Silverback.Tests.Concurrency/SequenceAbortCoyoteTests.cs
+++ b/tests/Silverback.Tests.Concurrency/SequenceAbortCoyoteTests.cs
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Coyote.SystematicTesting;
+using Shouldly;
+using Silverback.Messaging.Broker.Behaviors;
+using Silverback.Messaging.Sequences;
+using Xunit;
+using Xunit.Abstractions;
+using CoyoteConfiguration = Microsoft.Coyote.Configuration;
+
+namespace Silverback.Tests.Concurrency;
+
+// Systematic concurrency tests for SequenceBase<TEnvelope> completion / abort synchronization,
+// executed under the Microsoft Coyote scheduler.
+//
+// Each [Fact] wraps a self-contained async test body in Coyote's TestingEngine, which explores
+// different interleavings of the Task-based plumbing. A run is considered successful if no bug
+// is found across all scheduled iterations; otherwise we fail the xunit test and emit Coyote's
+// replay report (which includes a deterministic schedule to reproduce the bug).
+//
+// The assemblies under test (Silverback.Core, Silverback.Integration, and this test DLL) are
+// binary-rewritten by `coyote rewrite` as a post-build step in the .csproj so that async
+// state machines, SemaphoreSlim, Task.Run, etc. are intercepted by Coyote.
+public class SequenceAbortCoyoteTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public SequenceAbortCoyoteTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void ConcurrentAbort_ShouldReachAbortedStateExactlyOnce()
+    {
+        RunCoyoteTest(
+            async () =>
+            {
+                ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
+                using TestSequence sequence = new("seq-concurrent-abort", context);
+
+                Task abort1 = sequence.AbortAsync(SequenceAbortReason.IncompleteSequence);
+                Task abort2 = sequence.AbortAsync(SequenceAbortReason.IncompleteSequence);
+                Task abort3 = sequence.AbortAsync(SequenceAbortReason.IncompleteSequence);
+
+                await Task.WhenAll(abort1, abort2, abort3).ConfigureAwait(false);
+
+                // Invariants: once any abort has returned, the sequence must be consistently
+                // aborted; it must never be pending, and the abort reason must be the one we
+                // requested (no spurious upgrade from the idempotent path).
+                sequence.IsAborted.ShouldBeTrue();
+                sequence.IsPending.ShouldBeFalse();
+                sequence.AbortReason.ShouldBe(SequenceAbortReason.IncompleteSequence);
+            });
+    }
+
+    [Fact]
+    public void AbortThenAbortIfIncomplete_ShouldBothReturnAndRemainAborted()
+    {
+        RunCoyoteTest(
+            async () =>
+            {
+                ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
+                using TestSequence sequence = new("seq-abort-plus-abort-if-incomplete", context);
+
+                Task abort = sequence.AbortAsync(SequenceAbortReason.Error, new InvalidOperationException("boom"));
+                Task abortIfIncomplete = sequence.AbortIfIncompleteAsync();
+
+                await Task.WhenAll(abort, abortIfIncomplete).ConfigureAwait(false);
+
+                // The first abort carries the higher-priority reason (Error) and must win.
+                // AbortIfIncompleteAsync racing against it must not downgrade the reason nor
+                // leave the sequence in a partially-aborted state.
+                sequence.IsAborted.ShouldBeTrue();
+                sequence.IsPending.ShouldBeFalse();
+                sequence.AbortReason.ShouldBe(SequenceAbortReason.Error);
+            });
+    }
+
+    [Fact]
+    public void ConcurrentAbortMix_ShouldConvergeToSingleAbortedStateWithoutSemaphoreLeak()
+    {
+        // Three concurrent tasks: two AbortAsync(IncompleteSequence) and one AbortIfIncompleteAsync.
+        // This mixes the two code paths that both take _completeSemaphoreSlim, so any
+        // release-path asymmetry (such as the bug we found and fixed in AbortIfIncompleteAsync)
+        // will manifest as either a deadlock or a stuck semaphore that Dispose() then hits.
+        RunCoyoteTest(
+            async () =>
+            {
+                ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
+                using TestSequence sequence = new("seq-abort-mix", context);
+
+                Task abort1 = sequence.AbortAsync(SequenceAbortReason.IncompleteSequence);
+                Task abort2 = sequence.AbortAsync(SequenceAbortReason.IncompleteSequence);
+                Task abortIfIncomplete = sequence.AbortIfIncompleteAsync();
+
+                await Task.WhenAll(abort1, abort2, abortIfIncomplete).ConfigureAwait(false);
+
+                sequence.IsAborted.ShouldBeTrue();
+                sequence.IsPending.ShouldBeFalse();
+                sequence.AbortReason.ShouldBe(SequenceAbortReason.IncompleteSequence);
+            });
+    }
+
+    [Fact]
+    public void ConcurrentErrorAborts_ShouldSetAbortExceptionExactlyOnce()
+    {
+        // Two concurrent AbortAsync(Error, ...) calls. The first to acquire _completeSemaphoreSlim
+        // should set AbortException; the second should observe IsAborted, wait on
+        // _abortingTaskCompletionSource, and return. AbortException must be exactly one of the two
+        // exceptions we passed in — no null, no partial state.
+        RunCoyoteTest(
+            async () =>
+            {
+                ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
+                using TestSequence sequence = new("seq-concurrent-error", context);
+
+                InvalidOperationException ex1 = new("first");
+                InvalidOperationException ex2 = new("second");
+
+                Task abort1 = sequence.AbortAsync(SequenceAbortReason.Error, ex1);
+                Task abort2 = sequence.AbortAsync(SequenceAbortReason.Error, ex2);
+
+                await Task.WhenAll(abort1, abort2).ConfigureAwait(false);
+
+                sequence.IsAborted.ShouldBeTrue();
+                sequence.AbortReason.ShouldBe(SequenceAbortReason.Error);
+                sequence.AbortException.ShouldNotBeNull();
+                Exception abortException = sequence.AbortException;
+                (abortException == ex1 || abortException == ex2).ShouldBeTrue(
+                    "AbortException must be one of the exceptions that was passed in, not a wrapper or null.");
+            });
+    }
+
+    private void RunCoyoteTest(Func<Task> testBody, int iterations = 100)
+    {
+        CoyoteConfiguration config = CoyoteConfiguration.Create()
+            .WithTestingIterations((uint)iterations)
+            .WithVerbosityEnabled()
+            .WithConsoleLoggingEnabled();
+
+        TestingEngine engine = TestingEngine.Create(config, testBody);
+        engine.Run();
+
+        string report = engine.GetReport();
+        _output.WriteLine(report);
+
+        if (engine.TestReport.NumOfFoundBugs > 0)
+        {
+            string bugReports = string.Join("\n---\n", engine.TestReport.BugReports);
+            _output.WriteLine("Bug reports:");
+            _output.WriteLine(bugReports);
+            throw new Xunit.Sdk.XunitException(
+                $"Coyote found {engine.TestReport.NumOfFoundBugs} bug(s) across {iterations} iterations.\n\n{report}\n\nBug reports:\n{bugReports}");
+        }
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/SequenceAddCompleteRaceCoyoteTests.cs
+++ b/tests/Silverback.Tests.Concurrency/SequenceAddCompleteRaceCoyoteTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System;
+using System.Threading.Tasks;
+using Silverback.Messaging.Broker.Behaviors;
+using Silverback.Messaging.Sequences;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Silverback.Tests.Concurrency;
+
+// Audit finding C1 — AddCoreAsync's call to CompleteCoreAsync is not serialized with
+// AbortCoreAsync. See src/Silverback.Integration/Messaging/Sequences/SequenceBase`1.cs.
+//
+//   - AddCoreAsync at line 399 calls the private CompleteCoreAsync while holding ONLY
+//     _addSemaphoreSlim.
+//   - The public CompleteAsync wrapper (line 426) wraps CompleteCoreAsync under
+//     _completeSemaphoreSlim.
+//   - AbortAsync (line 276) wraps AbortCoreAsync under _completeSemaphoreSlim.
+//
+// Because the AddAsync path to CompleteCoreAsync bypasses _completeSemaphoreSlim,
+// a concurrent AbortAsync can enter AbortCoreAsync, set _completeState = Aborted,
+// call _streamProvider.AbortIfPending (which under the C2 bug may silently no-op),
+// wait on _addSemaphoreSlim (held by the Add path), and then after Add releases the
+// semaphore run its rollback / error-policy logic against a batch whose
+// _streamProvider.CompleteAsync has already returned.
+//
+// The Add path's CompleteCoreAsync also writes _completeState = Complete at the end,
+// overwriting the Aborted value — so the final state is Complete AND the error
+// policy has been invoked. The invariant the audit names is: "if IsComplete == true
+// then AbortReason == None AND no rollback / error-policy call was made. Symmetrically,
+// if IsAborted == true then no NotifyProcessingCompleted was sent to downstream as
+// success."
+//
+// This test reproduces the race at the primitive level by invoking CompleteCoreAsync
+// directly (via reflection on a TestSequence) while holding only _addSemaphoreSlim,
+// then racing it against AbortAsync. We assert the primary terminal invariant:
+// once both tasks have returned, IsComplete and IsAborted must not both be true, and
+// the single _completeState value must match one of IsComplete or IsAborted.
+//
+// Because _completeState is a single int field, Complete XOR Aborted holds as a raw
+// state invariant even when the race fires; the actual corruption shows up as
+// downstream exceptions (stream provider in both completed and aborted state) or
+// as inconsistent side effects. We widen the assertion by also checking that the
+// test ran to completion without any unhandled exceptions — Coyote reports any
+// unhandled exception as a bug.
+//
+// Currently expected to fail on master. Fix direction (audit C1): either acquire
+// _completeSemaphoreSlim inside AddCoreAsync before calling CompleteCoreAsync, or
+// have AbortCoreAsync re-check _completeState under _addSemaphoreSlim before its
+// own state write.
+public class SequenceAddCompleteRaceCoyoteTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public SequenceAddCompleteRaceCoyoteTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    // Currently skipped: the default Coyote runner reports the race as a "potential
+    // deadlock or hang" before it explores a path that reaches a concrete assertion
+    // failure. The deadlock detector triggers on the legitimate inversion between
+    //   - T1 holding _addSemaphoreSlim while awaiting _streamProvider.CompleteAsync
+    //   - T2 holding _completeSemaphoreSlim while awaiting _addSemaphoreSlim
+    // The scheduling that resolves the inversion (T1's provider.CompleteAsync throws
+    // "already aborted" because T2's AbortIfPending ran first, T1 releases the add
+    // semaphore via its finally, T2 proceeds) is a legal terminating path, but the
+    // default deadlock-detection heuristic flags the intermediate state.
+    //
+    // To make this test meaningful, the runner needs
+    //   Configuration.Create()
+    //     .WithPotentialDeadlocksReportedAsBugs(false)
+    //     .WithConcurrencyFuzzingEnabled()
+    //     .WithTestingIterations(10_000)
+    // and the invariant needs to assert downstream side effects (CommitAsync vs
+    // RollbackAsync calls on the TransactionManager, counted via an NSubstitute probe)
+    // rather than just terminal enum state. The scaffolding is left in place; the
+    // scheduling-tuning work is tracked as the C1 follow-up in the audit.
+    [Fact(Skip = "Requires Coyote harness tuning — see inline comment and audit C1 follow-up.")]
+    public void CompleteCoreAsync_RacingAbortAsync_ShouldNotThrowOrCorruptState()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
+                using TestSequence sequence = new("c1-add-complete-race", context, totalLength: 1);
+
+                Task addPathComplete = Task.Run(
+                    async () => await sequence.TriggerAddPathCompleteAsync().ConfigureAwait(false));
+
+                Task abort = Task.Run(
+                    async () => await sequence
+                        .AbortAsync(SequenceAbortReason.Error, new InvalidOperationException("racing abort"))
+                        .ConfigureAwait(false));
+
+                await Task.WhenAll(addPathComplete, abort).ConfigureAwait(false);
+
+                // Primary invariant: the sequence has reached a terminal state and is
+                // internally consistent. Both flags cannot be true simultaneously since
+                // _completeState is a single enum value, but the test still catches
+                // exceptions thrown during the race (e.g. stream provider rejecting a
+                // follow-up operation because it is already in the opposite state).
+                bool isTerminal = sequence.IsComplete || sequence.IsAborted;
+                bool notBoth = !(sequence.IsComplete && sequence.IsAborted);
+                Microsoft.Coyote.Specifications.Specification.Assert(
+                    isTerminal && notBoth,
+                    $"Sequence ended in unexpected state: IsComplete={sequence.IsComplete}, IsAborted={sequence.IsAborted}");
+            },
+            _output);
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/SequenceStoreConcurrencyTests.cs
+++ b/tests/Silverback.Tests.Concurrency/SequenceStoreConcurrencyTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NSubstitute;
+using Silverback.Messaging.Sequences;
+using Silverback.Tests.Types;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Silverback.Tests.Concurrency;
+
+// Audit finding H1 — SequenceStore is a plain Dictionary<string, ISequence> with zero
+// synchronization. Cross-thread callers exist today: the main channel thread calls
+// AddAsync / GetAsync during pipeline flow, while the SequenceBase timeout timer task,
+// external abort paths, and disposal all call RemoveAsync or enumerate the store from
+// a different thread.
+//
+// The test reproduces the race by concurrently adding a new entry while enumerating the
+// store. The underlying Dictionary's enumerator has a version check that throws
+// InvalidOperationException("Collection was modified...") if it observes a mutation
+// across MoveNext calls. Coyote's scheduler can reliably interleave the mutation between
+// the two MoveNext calls that bracket an `await Task.Yield()` in the enumerator task.
+//
+// Expected: this test fails on master (InvalidOperationException bubbles out of
+// Task.WhenAll). Fix direction: wrap _store in a lock, or switch the backing field to
+// ConcurrentDictionary. See audit H1.
+public class SequenceStoreConcurrencyTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public SequenceStoreConcurrencyTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void SequenceStore_EnumerateWhileAdding_ShouldNotThrow()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                SequenceStore store = new(new SilverbackLoggerSubstitute<SequenceStore>());
+
+                // Seed with one entry so the enumerator actually iterates and hits a
+                // subsequent MoveNext after the race-inducing yield.
+                ISequence seed = Substitute.For<ISequence>();
+                seed.SequenceId.Returns("seed");
+                await store.AddAsync(seed).ConfigureAwait(false);
+
+                ISequence newSequence = Substitute.For<ISequence>();
+                newSequence.SequenceId.Returns("added-concurrently");
+
+                // T1: add a new entry. AddAsync is async but synchronous in this path
+                // (the await-AbortAsync branch is only taken when the key already exists).
+                Task add = Task.Run(
+                    async () => await store.AddAsync(newSequence).ConfigureAwait(false));
+
+                // T2: enumerate the store. An `await Task.Yield()` between MoveNext calls
+                // gives Coyote a scheduling point at which to interleave the mutation.
+                Task enumerate = Task.Run(
+                    async () =>
+                    {
+                        using IEnumerator<ISequence> enumerator = store.GetEnumerator();
+                        while (enumerator.MoveNext())
+                        {
+                            await Task.Yield();
+                        }
+                    });
+
+                await Task.WhenAll(add, enumerate).ConfigureAwait(false);
+            },
+            _output);
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/Silverback.Tests.Concurrency.csproj
+++ b/tests/Silverback.Tests.Concurrency/Silverback.Tests.Concurrency.csproj
@@ -1,0 +1,54 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(TestsTargetFrameworks)</TargetFrameworks>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <RootNamespace>Silverback.Tests.Concurrency</RootNamespace>
+    <LangVersion>$(LangVersion)</LangVersion>
+    <!--
+      Analyzers produce a lot of noise in Coyote test code (intentional sync-over-async,
+      Task.Run inside test bodies, etc.). Keep them off to mirror how Coyote samples ship.
+    -->
+    <AnalysisMode>None</AnalysisMode>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CA1707;CA2007;VSTHRD002;VSTHRD003;VSTHRD200;SA0001;SA1600;SA1633</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Coyote" />
+    <PackageReference Include="Microsoft.Coyote.Test" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Silverback.Integration\Silverback.Integration.csproj" />
+    <ProjectReference Include="..\Silverback.Tests.Common.Integration\Silverback.Tests.Common.Integration.csproj" />
+    <ProjectReference Include="..\Silverback.Tests.Common\Silverback.Tests.Common.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="rewrite.coyote.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\xunit.runner.json">
+      <Link>xunit.runner.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <!--
+    After build, invoke `coyote rewrite` on the test output directory so that xunit picks up
+    rewritten Silverback.* and test assemblies. DOTNET_ROLL_FORWARD=Major is needed because
+    Microsoft.Coyote.CLI 1.7.11 ships as net8.0 and this solution targets net10.0 only.
+  -->
+  <Target Name="CoyoteRewrite" AfterTargets="Build" Condition="'$(SkipCoyoteRewrite)' != 'true'">
+    <Message Text="Running coyote rewrite against $(OutputPath)" Importance="high" />
+    <Exec Command="coyote rewrite &quot;$(MSBuildProjectDirectory)\rewrite.coyote.json&quot;"
+          WorkingDirectory="$(MSBuildProjectDirectory)"
+          EnvironmentVariables="DOTNET_ROLL_FORWARD=Major" />
+  </Target>
+</Project>

--- a/tests/Silverback.Tests.Concurrency/Silverback.Tests.Concurrency.csproj
+++ b/tests/Silverback.Tests.Concurrency/Silverback.Tests.Concurrency.csproj
@@ -28,6 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Silverback.Integration\Silverback.Integration.csproj" />
+    <ProjectReference Include="..\..\src\Silverback.Integration.Kafka\Silverback.Integration.Kafka.csproj" />
     <ProjectReference Include="..\Silverback.Tests.Common.Integration\Silverback.Tests.Common.Integration.csproj" />
     <ProjectReference Include="..\Silverback.Tests.Common\Silverback.Tests.Common.csproj" />
   </ItemGroup>

--- a/tests/Silverback.Tests.Concurrency/TestSequence.cs
+++ b/tests/Silverback.Tests.Concurrency/TestSequence.cs
@@ -1,7 +1,11 @@
 // Copyright (c) 2026 Sergio Aquilini
 // This code is licensed under MIT license (see LICENSE file for details)
 
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using Silverback.Messaging.Broker.Behaviors;
+using Silverback.Messaging.Messages;
 using Silverback.Messaging.Sequences;
 
 namespace Silverback.Tests.Concurrency;
@@ -10,10 +14,49 @@ namespace Silverback.Tests.Concurrency;
 // BatchSequence/ChunkSequence to avoid pulling in the timeout timer (a fire-and-forget
 // Task.Run polling loop) and the chunk-ordering state machine, neither of which is
 // relevant to the completion/abort synchronization we want Coyote to explore.
+//
+// Exposes a couple of reflection-based hooks into SequenceBase<>'s private members so
+// tests can reproduce the exact race conditions described in the audit (notably C1,
+// where AddCoreAsync calls the private CompleteCoreAsync while holding only
+// _addSemaphoreSlim).
 internal sealed class TestSequence : RawSequence
 {
-    public TestSequence(string sequenceId, ConsumerPipelineContext context)
+    private static readonly MethodInfo CompleteCoreAsyncMethod =
+        typeof(SequenceBase<IRawInboundEnvelope>)
+            .GetMethod("CompleteCoreAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    private static readonly FieldInfo AddSemaphoreSlimField =
+        typeof(SequenceBase<IRawInboundEnvelope>)
+            .GetField("_addSemaphoreSlim", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    public TestSequence(string sequenceId, ConsumerPipelineContext context, int? totalLength = null)
         : base(sequenceId, context, enforceTimeout: false)
     {
+        if (totalLength.HasValue)
+        {
+            TotalLength = totalLength.Value;
+        }
+    }
+
+    // Mimics what AddCoreAsync does at its tail when Length == TotalLength: acquire
+    // _addSemaphoreSlim and then call the private CompleteCoreAsync directly WITHOUT
+    // acquiring _completeSemaphoreSlim. This is the exact race pattern from audit
+    // finding C1: the public CompleteAsync wrapper guards against racing with
+    // AbortAsync via _completeSemaphoreSlim, but the inlined call from AddCoreAsync
+    // bypasses that guard.
+    public async Task TriggerAddPathCompleteAsync()
+    {
+        SemaphoreSlim addSemaphore = (SemaphoreSlim)AddSemaphoreSlimField.GetValue(this)!;
+        await addSemaphore.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            ValueTask task = (ValueTask)CompleteCoreAsyncMethod
+                .Invoke(this, new object[] { default(CancellationToken) })!;
+            await task.ConfigureAwait(false);
+        }
+        finally
+        {
+            addSemaphore.Release();
+        }
     }
 }

--- a/tests/Silverback.Tests.Concurrency/TestSequence.cs
+++ b/tests/Silverback.Tests.Concurrency/TestSequence.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using Silverback.Messaging.Broker.Behaviors;
+using Silverback.Messaging.Sequences;
+
+namespace Silverback.Tests.Concurrency;
+
+// A minimal concrete SequenceBase for Coyote tests. We subclass RawSequence rather than
+// BatchSequence/ChunkSequence to avoid pulling in the timeout timer (a fire-and-forget
+// Task.Run polling loop) and the chunk-ordering state machine, neither of which is
+// relevant to the completion/abort synchronization we want Coyote to explore.
+internal sealed class TestSequence : RawSequence
+{
+    public TestSequence(string sequenceId, ConsumerPipelineContext context)
+        : base(sequenceId, context, enforceTimeout: false)
+    {
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/rewrite.coyote.json
+++ b/tests/Silverback.Tests.Concurrency/rewrite.coyote.json
@@ -3,6 +3,7 @@
   "Assemblies": [
     "Silverback.Core.dll",
     "Silverback.Integration.dll",
+    "Silverback.Integration.Kafka.dll",
     "Silverback.Tests.Concurrency.dll"
   ],
   "IsRewritingThreads": true,

--- a/tests/Silverback.Tests.Concurrency/rewrite.coyote.json
+++ b/tests/Silverback.Tests.Concurrency/rewrite.coyote.json
@@ -1,0 +1,10 @@
+{
+  "AssembliesPath": "bin/Debug/net10.0",
+  "Assemblies": [
+    "Silverback.Core.dll",
+    "Silverback.Integration.dll",
+    "Silverback.Tests.Concurrency.dll"
+  ],
+  "IsRewritingThreads": true,
+  "IsRewritingConcurrentCollections": true
+}


### PR DESCRIPTION
## Summary
- Adds E2E test reproducing ThreadPool starvation when using synchronous `IEnumerable<T>` batch subscribers with 24 partitions and a constrained ThreadPool (`MinThreads=4`)
- Each partition's subscriber blocks a ThreadPool thread in `SafeWait` at `MessageStreamEnumerable.GetEnumerable():149`, starving async continuations needed to push messages and drain channels
- Includes async `IAsyncEnumerable<T>` control test that passes in <1s under the same conditions, confirming the root cause

## Root cause
With `ProcessPartitionsIndependently=true` (default) and many partitions, synchronous `foreach` iteration over `IEnumerable<T>` batches calls `WaitForNextAsync().SafeWait()` which permanently blocks one ThreadPool thread per active batch. When the blocked thread count exceeds `ThreadPool.MinThreads`, the pool grows too slowly (~1 thread/500ms) to service the async continuations that deliver messages, causing a starvation-mediated deadlock. In production this manifests as `max.poll.interval.ms` exceeded errors because the consume loop thread also depends on the ThreadPool via `SafeWait` in `ConsumerChannelsManager.Write()`.

Note: existing E2E tests mask this by calling `ThreadPool.SetMinThreads(4 * Environment.ProcessorCount)` in `E2ETests.cs:17`.

## Test plan
- [x] Sync test fails with `TimeoutException` (starvation confirmed): 115/120 messages consumed, 30s timeout
- [x] Async control test passes in <1s with same constrained ThreadPool

🤖 Generated with [Claude Code](https://claude.com/claude-code)