### PR TITLE
test: E2E stress tests for Kafka (24 partitions) and MQTT (rapid production)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,8 @@
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.7.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.103" />
+    <PackageVersion Include="Microsoft.Coyote" Version="1.7.11" />
+    <PackageVersion Include="Microsoft.Coyote.Test" Version="1.7.11" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="10.0.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />

--- a/Silverback.sln
+++ b/Silverback.sln
@@ -130,6 +130,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Silverback.Storage.Relation
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Silverback.Tools.Generators.Docs.Headers", "tools\Silverback.Tools.Generators.Docs.Headers\Silverback.Tools.Generators.Docs.Headers.csproj", "{5AB6F39A-5B87-461D-9E6A-C2847016AC7D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Silverback.Tests.Concurrency", "tests\Silverback.Tests.Concurrency\Silverback.Tests.Concurrency.csproj", "{C07E10A1-CC00-4FFF-A0A0-000000000001}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -308,6 +310,10 @@ Global
 		{5AB6F39A-5B87-461D-9E6A-C2847016AC7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5AB6F39A-5B87-461D-9E6A-C2847016AC7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5AB6F39A-5B87-461D-9E6A-C2847016AC7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C07E10A1-CC00-4FFF-A0A0-000000000001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C07E10A1-CC00-4FFF-A0A0-000000000001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C07E10A1-CC00-4FFF-A0A0-000000000001}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C07E10A1-CC00-4FFF-A0A0-000000000001}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -342,6 +348,7 @@ Global
 		{5244CA89-97CA-418E-8976-357057A104F6} = {6AFB87A3-501B-4A87-B94C-205AEB118D97}
 		{9C26779F-D843-4B87-BCE5-ABC283E6A16B} = {6AFB87A3-501B-4A87-B94C-205AEB118D97}
 		{5AB6F39A-5B87-461D-9E6A-C2847016AC7D} = {9818A770-01ED-4340-BD4A-CFDDA6C56168}
+		{C07E10A1-CC00-4FFF-A0A0-000000000001} = {6AFB87A3-501B-4A87-B94C-205AEB118D97}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {89DA4AF5-B982-42AD-A829-8A72BCB21227}

--- a/src/Silverback.Core/Silverback.Core.csproj
+++ b/src/Silverback.Core/Silverback.Core.csproj
@@ -46,6 +46,9 @@
       <_Parameter1>Silverback.Integration.Tests</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Silverback.Tests.Concurrency</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Silverback.Integration.Tests.E2E</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/src/Silverback.Integration/Silverback.Integration.csproj
+++ b/src/Silverback.Integration/Silverback.Integration.csproj
@@ -31,6 +31,9 @@
       <_Parameter1>Silverback.Integration.Tests</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Silverback.Tests.Concurrency</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Silverback.Integration.Kafka</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/tests/Silverback.Integration.Tests.E2E/Stress/KafkaBatchStressTests.cs
+++ b/tests/Silverback.Integration.Tests.E2E/Stress/KafkaBatchStressTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Silverback.Configuration;
+using Silverback.Messaging.Broker;
+using Silverback.Messaging.Configuration;
+using Silverback.Messaging.Messages;
+using Silverback.Tests.Integration.E2E.TestHost;
+using Silverback.Tests.Integration.E2E.TestTypes.Messages;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Silverback.Tests.Integration.E2E.Stress;
+
+/// <summary>
+///     Hammers the Kafka consumer pipeline with 24 partitions and 5000+ messages
+///     using sync batch subscribers. Designed to surface known concurrency bugs
+///     under realistic end-to-end load:
+///     <list type="bullet">
+///         <item>C3: ConsumerChannelsManager semaphore leak after partition count fluctuation</item>
+///         <item>H1: SequenceStore unsynchronized Dictionary under 24 concurrent readers/writers</item>
+///         <item>AbortIfIncompleteAsync: semaphore leak when incomplete batches are aborted</item>
+///     </list>
+///     Expected to fail on the current codebase (timeout or assertion failure).
+/// </summary>
+[Trait("Type", "Stress")]
+[Trait("Broker", "Kafka")]
+public class KafkaBatchStressTests : KafkaTests
+{
+    private const string StressTopicName = "stress-topic";
+
+    private const string StressGroupId = "stress-group";
+
+    private const int PartitionCount = 24;
+
+    private const int BatchSize = 50;
+
+    private const int TotalMessages = 5040; // 24 * 210: each partition gets 4 full batches + 10 remainder
+
+    public KafkaBatchStressTests(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task HighPartitionBatchProcessing_ShouldConsumeAllMessagesWithoutLoss()
+    {
+        ConcurrentBag<string> receivedContent = [];
+        int completedBatches = 0;
+
+        await Host.ConfigureServicesAndRunAsync(
+            services => services
+                .AddLogging()
+                .AddSilverback()
+                .WithConnectionToMessageBroker(
+                    options => options
+                        .AddMockedKafka(mockOptions => mockOptions.WithDefaultPartitionsCount(PartitionCount)))
+                .AddKafkaClients(
+                    clients => clients
+                        .WithBootstrapServers("PLAINTEXT://stress")
+                        .AddConsumer(
+                            consumer => consumer
+                                .WithGroupId(StressGroupId)
+                                .CommitOffsetEach(1)
+                                .Consume<TestEventOne>(
+                                    endpoint => endpoint
+                                        .ConsumeFrom(StressTopicName)
+                                        .EnableBatchProcessing(BatchSize))))
+                .AddDelegateSubscriber<IMessageStreamEnumerable<TestEventOne>>(HandleBatch));
+
+        // Sync subscriber: each partition blocks a ThreadPool thread in MoveNext via SafeWait.
+        // 24 partitions = 24 blocked threads. This is the thread starvation path.
+        void HandleBatch(IMessageStreamEnumerable<TestEventOne> batch)
+        {
+            foreach (TestEventOne message in batch)
+            {
+                receivedContent.Add(message.ContentEventOne!);
+            }
+
+            Interlocked.Increment(ref completedBatches);
+        }
+
+        IProducer producer = Helper.GetProducer(
+            producer => producer
+                .WithBootstrapServers("PLAINTEXT://stress")
+                .Produce<TestEventOne>(
+                    endpoint => endpoint
+                        .ProduceTo(StressTopicName)
+                        .SetKafkaKey(envelope => envelope.Message?.ContentEventOne)));
+
+        for (int i = 0; i < TotalMessages; i++)
+        {
+            await producer.ProduceAsync(new TestEventOne { ContentEventOne = $"{i}" });
+        }
+
+        await Helper.WaitUntilAllMessagesAreConsumedAsync();
+
+        // No message loss
+        receivedContent.Count.ShouldBe(
+            TotalMessages,
+            $"Received {receivedContent.Count}/{TotalMessages} messages. " +
+            "Possible causes: C3 semaphore leak starving message handlers, " +
+            "H1 SequenceStore dictionary corruption losing sequences, " +
+            "or thread starvation from 24 sync batch subscribers.");
+
+        // No duplicates
+        receivedContent.Distinct().Count().ShouldBe(
+            TotalMessages,
+            "Duplicate messages detected.");
+
+        // All offsets committed
+        IMockedConsumerGroup consumerGroup = Helper.GetConsumerGroup(StressGroupId);
+        consumerGroup.GetCommittedOffsetsCount(StressTopicName).ShouldBe(TotalMessages);
+    }
+}

--- a/tests/Silverback.Integration.Tests.E2E/Stress/MqttConcurrencyStressTests.cs
+++ b/tests/Silverback.Integration.Tests.E2E/Stress/MqttConcurrencyStressTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Silverback.Configuration;
+using Silverback.Messaging.Broker;
+using Silverback.Messaging.Configuration;
+using Silverback.Tests.Integration.E2E.TestHost;
+using Silverback.Tests.Integration.E2E.TestTypes.Messages;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Silverback.Tests.Integration.E2E.Stress;
+
+/// <summary>
+///     Hammers the MQTT consumer pipeline with 1200 messages produced concurrently
+///     to maximize callback overlap in <c>OnMessageReceivedAsync</c>. Designed to
+///     surface known concurrency bugs under realistic load:
+///     <list type="bullet">
+///         <item>MC1: _nextChannelIndex non-atomic increment losing message routing</item>
+///         <item>MC2: publish queue channel recreation race on reconnect</item>
+///     </list>
+///     Expected to fail on the current codebase (timeout or assertion failure).
+/// </summary>
+[Trait("Type", "Stress")]
+[Trait("Broker", "MQTT")]
+public class MqttConcurrencyStressTests : MqttTests
+{
+    private const string StressTopicName = "stress/topic";
+
+    private const string StressClientId = "stress-client";
+
+    private const int TotalMessages = 1200;
+
+    public MqttConcurrencyStressTests(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task RapidProduction_ShouldConsumeAllMessagesWithoutLoss()
+    {
+        ConcurrentBag<string> receivedContent = [];
+
+        await Host.ConfigureServicesAndRunAsync(
+            services => services
+                .AddLogging()
+                .AddSilverback()
+                .WithConnectionToMessageBroker(options => options.AddMockedMqtt())
+                .AddMqttClients(
+                    clients => clients
+                        .ConnectViaTcp("stress-mqtt-broker")
+                        .AddClient(
+                            client => client
+                                .WithClientId(StressClientId)
+                                .Produce<IIntegrationEvent>(
+                                    endpoint => endpoint.ProduceTo(StressTopicName))
+                                .Consume(
+                                    endpoint => endpoint.ConsumeFrom(StressTopicName))))
+                .AddDelegateSubscriber<TestEventOne>(HandleMessage));
+
+        // Sync subscriber with a spin to increase the chance of concurrent
+        // MQTTnet callbacks overlapping in OnMessageReceivedAsync.
+        void HandleMessage(TestEventOne message)
+        {
+            receivedContent.Add(message.ContentEventOne!);
+            Thread.SpinWait(100);
+        }
+
+        IPublisher publisher = Host.ServiceProvider.GetRequiredService<IPublisher>();
+
+        // Rapid-fire: produce all messages concurrently to maximize callback overlap
+        Task[] produceTasks = Enumerable.Range(0, TotalMessages)
+            .Select(i => publisher.PublishEventAsync(
+                new TestEventOne { ContentEventOne = $"{i}" }).AsTask())
+            .ToArray();
+
+        await Task.WhenAll(produceTasks);
+        await Helper.WaitUntilAllMessagesAreConsumedAsync();
+
+        // No message loss
+        receivedContent.Count.ShouldBe(
+            TotalMessages,
+            $"Received {receivedContent.Count}/{TotalMessages} messages. " +
+            "Possible causes: MC1 (_nextChannelIndex race routing messages " +
+            "to wrong/skipped channels), or thread starvation from sync " +
+            "subscriber blocking ThreadPool threads.");
+
+        // No duplicates
+        receivedContent.Distinct().Count().ShouldBe(
+            TotalMessages,
+            "Duplicate messages detected.");
+
+        // All expected indices present
+        HashSet<string> expected = [.. Enumerable.Range(0, TotalMessages).Select(i => $"{i}")];
+        HashSet<string> received = [.. receivedContent];
+        HashSet<string> missing = [.. expected.Except(received)];
+        missing.Count.ShouldBe(
+            0,
+            $"Missing {missing.Count} message(s). First 20: {string.Join(", ", missing.Take(20))}");
+    }
+}

--- a/tests/Silverback.Integration.Tests/Messaging/Sequences/SequenceBaseSemaphoreLeakTests.cs
+++ b/tests/Silverback.Integration.Tests/Messaging/Sequences/SequenceBaseSemaphoreLeakTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System;
+using System.Threading.Tasks;
+using Shouldly;
+using Silverback.Messaging.Broker.Behaviors;
+using Silverback.Messaging.Sequences;
+using Silverback.Messaging.Sequences.Chunking;
+using Xunit;
+
+namespace Silverback.Tests.Integration.Messaging.Sequences;
+
+// Non-Coyote reproducer for a semaphore leak in SequenceBase<TEnvelope>.AbortIfIncompleteAsync.
+// When the sequence is already aborted (or completed), AbortIfIncompleteAsync acquires
+// _completeSemaphoreSlim and then early-returns on the !IsPending check without releasing
+// it. The leak only bites on the next synchronous wait on that semaphore, which happens
+// inside Dispose().
+public class SequenceBaseSemaphoreLeakTests
+{
+    [Fact]
+    public async Task AbortIfIncompleteAsync_AfterAbort_ShouldNotLeakCompleteSemaphore()
+    {
+        ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
+        ChunkSequence sequence = new("leak-test", 10, context);
+
+        await sequence.AbortAsync(SequenceAbortReason.IncompleteSequence);
+        sequence.IsAborted.ShouldBeTrue();
+
+        // This is the call that leaks: it acquires _completeSemaphoreSlim, sees !IsPending,
+        // and returns without releasing.
+        await sequence.AbortIfIncompleteAsync();
+
+        // Dispose() performs a synchronous Wait() on _completeSemaphoreSlim. If the semaphore
+        // is leaked it will block here forever; we wrap the call in Task.Run with a timeout so
+        // the test fails cleanly rather than hanging.
+        Task disposeTask = Task.Run(sequence.Dispose);
+        Task finished = await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromSeconds(5)));
+
+        finished.ShouldBe(disposeTask, "Dispose() blocked — AbortIfIncompleteAsync leaked _completeSemaphoreSlim.");
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/ConsumerChannelsSemaphoreCoyoteTests.cs
+++ b/tests/Silverback.Tests.Concurrency/ConsumerChannelsSemaphoreCoyoteTests.cs
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System.Threading;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Silverback.Tests.Concurrency;
+
+// Audit finding C3 — ConsumerChannelsManager releases _messagesLimiterSemaphoreSlim based
+// on CurrentCount, not ownership.
+//
+// src/Silverback.Integration.Kafka/Messaging/Broker/Kafka/ConsumerChannelsManager.cs:150-165:
+//
+//   if (_channels.Count > _consumer.Configuration.MaxDegreeOfParallelism)
+//       await _messagesLimiterSemaphoreSlim.WaitAsync(...);  // conditional acquire
+//   try { await _consumer.HandleMessageAsync(...); }
+//   finally
+//   {
+//       if (_messagesLimiterSemaphoreSlim.CurrentCount < _consumer.Configuration.MaxDegreeOfParallelism)
+//           _messagesLimiterSemaphoreSlim.Release();          // condition != "did I acquire"
+//   }
+//
+// The interleaving that triggers the bug:
+//   1. T1, T2: acquire tokens (channelCount > maxDoP). Semaphore count = 0.
+//   2. Partition revoke: channelCount drops to <= maxDoP.
+//   3. T3: enters with channelCount <= maxDoP, skips acquire. Finishes. Finally sees
+//      CurrentCount=0 < maxDoP → releases a token it never owned. Count = 1.
+//   4. Partition reassignment: channelCount goes back above maxDoP.
+//   5. T4: acquires the extra token. Now T1, T2, T4 are all active simultaneously.
+//      Active count = 3 > maxDoP = 2. The limiter failed to limit.
+//
+// Over time, after many revoke/assign cycles, the leaked tokens accumulate in the
+// opposite direction too (under-release), eventually starving all message processing.
+// This matches the reported bug: "stops consuming after several thousand messages"
+// with 24 partitions.
+//
+// The test tracks peak concurrent active handlers and asserts it never exceeds maxDoP.
+//
+// Fix direction: capture `bool acquired` locally and release iff true.
+public class ConsumerChannelsSemaphoreCoyoteTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public ConsumerChannelsSemaphoreCoyoteTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void SemaphoreCurrentCountRelease_ShouldNotExceedMaxDoP_AfterChannelCountDrop()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                const int maxDoP = 2;
+                SemaphoreSlim limiter = new(maxDoP, maxDoP);
+                int channelCount = 4;
+
+                int active = 0;
+                int maxObservedActive = 0;
+
+                // Gate: holds T1/T2 mid-processing so they occupy their semaphore tokens
+                // while T3 enters, exits, and over-releases.
+                SemaphoreSlim gate = new(0, 4);
+
+                async Task ProcessHeld()
+                {
+                    if (channelCount > maxDoP)
+                        await limiter.WaitAsync().ConfigureAwait(false);
+
+                    try
+                    {
+                        InterlockedMax(ref maxObservedActive, Interlocked.Increment(ref active));
+                        await gate.WaitAsync().ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        Interlocked.Decrement(ref active);
+                        if (limiter.CurrentCount < maxDoP)
+                            limiter.Release();
+                    }
+                }
+
+                async Task ProcessQuick()
+                {
+                    if (channelCount > maxDoP)
+                        await limiter.WaitAsync().ConfigureAwait(false);
+
+                    try
+                    {
+                        InterlockedMax(ref maxObservedActive, Interlocked.Increment(ref active));
+                        await Task.Yield();
+                    }
+                    finally
+                    {
+                        Interlocked.Decrement(ref active);
+                        if (limiter.CurrentCount < maxDoP)
+                            limiter.Release();
+                    }
+                }
+
+                // Phase 1: T1, T2 acquire tokens and hold via gate.
+                // Semaphore count: 2 → 1 → 0. active = 2.
+                Task t1 = Task.Run(ProcessHeld);
+                Task t2 = Task.Run(ProcessHeld);
+                await Task.Yield();
+                await Task.Yield();
+
+                // Partition revoke: channels drop to <= maxDoP.
+                channelCount = 2;
+
+                // T3: enters, skips acquire (2 > 2 = false). Finishes quickly.
+                // T3 finally: CurrentCount = 0 < 2 → releases a token it never owned!
+                // Count: 0 → 1. active briefly 3 (T1 + T2 + T3), then back to 2.
+                Task t3 = Task.Run(ProcessQuick);
+                await t3.ConfigureAwait(false);
+
+                // Partition reassignment: channels go back up.
+                channelCount = 4;
+
+                // T4: acquires the over-released token. Count: 1 → 0.
+                // Now T1, T2, T4 are all active inside the try block.
+                // active = 3, which exceeds maxDoP = 2.
+                Task t4 = Task.Run(ProcessHeld);
+                await Task.Yield();
+                await Task.Yield();
+
+                // Release everyone
+                gate.Release(4);
+                await Task.WhenAll(t1, t2, t4).ConfigureAwait(false);
+
+                // Invariant: the semaphore should have prevented more than maxDoP
+                // concurrent active handlers at any point.
+                maxObservedActive.ShouldBeLessThanOrEqualTo(
+                    maxDoP,
+                    $"Peak concurrent active handlers was {maxObservedActive}, exceeding maxDoP={maxDoP}. " +
+                    "The CurrentCount-based release in ConsumerChannelsManager over-released a token " +
+                    "that was never acquired (after a channel-count drop), allowing more concurrent " +
+                    "processing than the limiter should permit. See audit C3.");
+            },
+            _output);
+    }
+
+    private static void InterlockedMax(ref int location, int value)
+    {
+        int current;
+        do
+        {
+            current = Volatile.Read(ref location);
+        }
+        while (value > current && Interlocked.CompareExchange(ref location, value, current) != current);
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/CoreConcurrencyPatternCoyoteTests.cs
+++ b/tests/Silverback.Tests.Concurrency/CoreConcurrencyPatternCoyoteTests.cs
@@ -1,0 +1,285 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Silverback.Tests.Concurrency;
+
+// Concurrency tests for Core and Integration patterns not covered by the
+// SequenceBase/MessageStreamProvider/SequenceStore tests.
+public class CoreConcurrencyPatternCoyoteTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public CoreConcurrencyPatternCoyoteTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    // #1 — LazyMessageStreamEnumerable TaskCompletionSource double-set.
+    //
+    // LazyMessageStreamEnumerable`1.cs:45-59:
+    //   GetOrCreateStream() calls _taskCompletionSource.SetResult(stream)
+    //   Cancel() calls _taskCompletionSource.SetCanceled()
+    //
+    // No synchronization. If a subscriber triggers GetOrCreateStream while
+    // the sequence abort path triggers Cancel, the TCS gets set twice.
+    // InvalidOperationException from the second Set is thrown in a
+    // fire-and-forget context, silently lost.
+    [Fact]
+    public void LazyStream_GetOrCreateRacingCancel_ShouldNotDoubleSetTcs()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                TaskCompletionSource<object> tcs = new();
+                object? createdStream = null;
+
+                // Mirrors GetOrCreateStream: check null, create, SetResult
+                Task create = Task.Run(
+                    () =>
+                    {
+                        if (createdStream == null)
+                        {
+                            createdStream = new object();
+                            tcs.SetResult(createdStream);
+                        }
+                    });
+
+                // Mirrors Cancel: SetCanceled
+                Task cancel = Task.Run(
+                    () =>
+                    {
+                        tcs.SetCanceled();
+                    });
+
+                // At least one must throw if both try to set.
+                // In production this exception is swallowed. Here we detect it.
+                bool exceptionObserved = false;
+                try
+                {
+                    await Task.WhenAll(create, cancel).ConfigureAwait(false);
+                }
+                catch (InvalidOperationException)
+                {
+                    exceptionObserved = true;
+                }
+                catch (TaskCanceledException)
+                {
+                    // SetCanceled won the race; that's one valid outcome
+                }
+
+                // Invariant: if no exception, exactly one of SetResult or SetCanceled
+                // should have succeeded. The TCS should be in a terminal state.
+                // The bug is that both CAN succeed in the absence of synchronization,
+                // which means the second call throws. In production that exception
+                // is lost (fire-and-forget), causing silent message loss.
+                if (exceptionObserved)
+                {
+                    // The race was caught: double-set occurred. This is the bug.
+                    true.ShouldBeFalse(
+                        "TaskCompletionSource was set twice (SetResult + SetCanceled raced). " +
+                        "LazyMessageStreamEnumerable.GetOrCreateStream and Cancel have no " +
+                        "synchronization; the second Set throws InvalidOperationException " +
+                        "which is silently lost in a fire-and-forget context. See finding #1.");
+                }
+            },
+            _output);
+    }
+
+    // #2 — ConsumerChannel CancellationTokenSource dispose-while-active.
+    //
+    // ConsumerChannel`1.cs:86-102:
+    //   StartReading() disposes _readCancellationTokenSource and creates a new one
+    //   if the old one is canceled. No lock. Concurrent readers that cached
+    //   ReadCancellationToken from the old source get ObjectDisposedException.
+    [Fact]
+    public void ConsumerChannel_StartReadingDisposingCts_ShouldNotThrow()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                CancellationTokenSource cts = new();
+                CancellationToken cachedToken = cts.Token;
+                bool objectDisposedObserved = false;
+
+                // T1: simulates StartReading — cancel then dispose+recreate
+                Task startReading = Task.Run(
+                    async () =>
+                    {
+                        await cts.CancelAsync().ConfigureAwait(false);
+                        cts.Dispose();
+                        cts = new CancellationTokenSource();
+                    });
+
+                // T2: simulates a reader that cached the old token
+                Task reader = Task.Run(
+                    () =>
+                    {
+                        try
+                        {
+                            // Access the token's properties — this throws if
+                            // the source was disposed
+                            _ = cachedToken.IsCancellationRequested;
+                            cachedToken.ThrowIfCancellationRequested();
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            objectDisposedObserved = true;
+                        }
+                    });
+
+                await Task.WhenAll(startReading, reader).ConfigureAwait(false);
+
+                objectDisposedObserved.ShouldBeFalse(
+                    "Reader observed ObjectDisposedException on a cached CancellationToken " +
+                    "after StartReading disposed and recreated the CancellationTokenSource. " +
+                    "ConsumerChannel.StartReading has no synchronization around the " +
+                    "dispose+recreate; concurrent readers that hold the old token crash. " +
+                    "See finding #2.");
+            },
+            _output);
+    }
+
+    // #4 — InMemoryKafkaOffsetStore: live collection escapes lock scope.
+    //
+    // InMemoryKafkaOffsetStore.cs:20-28:
+    //   GetStoredOffsets returns offsetsByTopicPartition.Values — a LIVE view
+    //   into the Dictionary. The lock is released before the caller enumerates.
+    //   StoreOffsetsAsync mutates the dictionary under lock, but the returned
+    //   Values collection sees the mutation without any lock protection.
+    [Fact]
+    public void InMemoryKafkaOffsetStore_EnumerateReturnedCollectionWhileStoring_ShouldNotThrow()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                // Model the pattern: Dictionary + lock on outer dict, return inner.Values
+                Dictionary<string, Dictionary<int, string>> store = new();
+                object lockObj = new();
+
+                // Seed
+                lock (lockObj)
+                {
+                    store["group1"] = new Dictionary<int, string> { [0] = "offset-0" };
+                }
+
+                // GetStoredOffsets: returns live .Values inside the lock, caller
+                // enumerates OUTSIDE the lock
+                ICollection<string>? liveValues = null;
+                lock (lockObj)
+                {
+                    if (store.TryGetValue("group1", out var inner))
+                        liveValues = inner.Values; // live view, not a snapshot
+                }
+
+                // T1: enumerate the live Values collection (outside the lock)
+                Task enumerate = Task.Run(
+                    async () =>
+                    {
+                        if (liveValues == null) return;
+                        using IEnumerator<string> enumerator = liveValues.GetEnumerator();
+                        while (enumerator.MoveNext())
+                        {
+                            await Task.Yield();
+                        }
+                    });
+
+                // T2: store new offsets (mutates the inner dict under lock)
+                Task storeOffsets = Task.Run(
+                    () =>
+                    {
+                        lock (lockObj)
+                        {
+                            store["group1"]![1] = "offset-1";
+                            store["group1"]![2] = "offset-2";
+                        }
+                    });
+
+                await Task.WhenAll(enumerate, storeOffsets).ConfigureAwait(false);
+            },
+            _output);
+    }
+
+    // #5 — EnumerableSelectExtensions.ParallelSelectAsync semaphore corruption.
+    //
+    // EnumerableSelectExtensions.cs:42-61:
+    //   semaphore.Release() is in the try block (not finally). If the selector
+    //   throws, the catch cancels the CTS but does NOT release the semaphore.
+    //   The semaphore token is leaked. Other tasks waiting on WaitAsync block
+    //   until the CTS cancellation propagates, but the semaphore count is
+    //   permanently reduced.
+    //
+    //   Additionally, if WaitAsync is canceled (by the CTS from another task's
+    //   exception), the OperationCanceledException propagates but the semaphore
+    //   was never acquired, so there's no leak in THAT path. The leak is
+    //   specifically: task acquires semaphore, selector throws, catch does NOT
+    //   release.
+    [Fact]
+    public void ParallelSelect_SelectorThrows_ShouldNotLeakSemaphoreToken()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                const int maxDoP = 2;
+                SemaphoreSlim semaphore = new(maxDoP);
+                using CancellationTokenSource cts = new();
+                int completed = 0;
+                bool leaked = false;
+
+                async Task<int> InvokeSelector(int value)
+                {
+                    await semaphore.WaitAsync(cts.Token).ConfigureAwait(false);
+                    try
+                    {
+                        // Mirrors the production pattern: Release in try, not finally
+                        if (value == 3)
+                            throw new InvalidOperationException("selector failure");
+
+                        await Task.Yield();
+                        Interlocked.Increment(ref completed);
+                        semaphore.Release();
+                        return value;
+                    }
+                    catch (Exception)
+                    {
+                        await cts.CancelAsync().ConfigureAwait(false);
+                        throw;
+                        // NOTE: semaphore is NOT released here — this is the bug
+                    }
+                }
+
+                try
+                {
+                    Task[] tasks = new[] { 1, 2, 3, 4, 5 }
+                        .Select(i => Task.Run(async () => await InvokeSelector(i).ConfigureAwait(false)))
+                        .ToArray();
+                    await Task.WhenAll(tasks).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Expected: one selector threw
+                }
+
+                // After all tasks settle, the semaphore count should equal maxDoP
+                // if all tokens were properly released. A leaked token means
+                // count < maxDoP.
+                if (semaphore.CurrentCount < maxDoP)
+                    leaked = true;
+
+                leaked.ShouldBeFalse(
+                    $"Semaphore count is {semaphore.CurrentCount}, expected {maxDoP}. " +
+                    "ParallelSelectAsync releases the semaphore in the try block, not " +
+                    "the finally. When the selector throws, the token is leaked. " +
+                    "See finding #5.");
+            },
+            _output);
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/CoyoteTestRunner.cs
+++ b/tests/Silverback.Tests.Concurrency/CoyoteTestRunner.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Coyote.SystematicTesting;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+using CoyoteConfiguration = Microsoft.Coyote.Configuration;
+
+namespace Silverback.Tests.Concurrency;
+
+// Shared helper that runs an async test body under the Microsoft.Coyote systematic testing
+// engine. Each test class takes an ITestOutputHelper and forwards it here so Coyote's report
+// and any bug traces land in the xunit test output.
+//
+// The test assemblies (Silverback.Core, Silverback.Integration, and this test DLL) are
+// binary-rewritten by `coyote rewrite` as a post-build step in the .csproj so that async
+// state machines, SemaphoreSlim, Task.Run, etc. are intercepted by Coyote's scheduler.
+internal static class CoyoteTestRunner
+{
+    // Default iteration count for most tests. Raise to 10k+ (and pass explicitly) for races
+    // that require aggressive scheduling exploration to reproduce.
+    public const int DefaultIterations = 100;
+
+    public static void Run(Func<Task> testBody, ITestOutputHelper output, int iterations = DefaultIterations)
+    {
+        CoyoteConfiguration config = CoyoteConfiguration.Create()
+            .WithTestingIterations((uint)iterations)
+            .WithVerbosityEnabled()
+            .WithConsoleLoggingEnabled();
+
+        TestingEngine engine = TestingEngine.Create(config, testBody);
+        engine.Run();
+
+        string report = engine.GetReport();
+        output.WriteLine(report);
+
+        if (engine.TestReport.NumOfFoundBugs > 0)
+        {
+            string bugReports = string.Join("\n---\n", engine.TestReport.BugReports);
+            output.WriteLine("Bug reports:");
+            output.WriteLine(bugReports);
+            throw new XunitException(
+                $"Coyote found {engine.TestReport.NumOfFoundBugs} bug(s) across {iterations} iterations.\n\n{report}\n\nBug reports:\n{bugReports}");
+        }
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/CoyoteTestRunner.cs
+++ b/tests/Silverback.Tests.Concurrency/CoyoteTestRunner.cs
@@ -30,6 +30,35 @@ internal static class CoyoteTestRunner
             .WithVerbosityEnabled()
             .WithConsoleLoggingEnabled();
 
+        RunWithConfig(config, testBody, output, iterations);
+    }
+
+    // Aggressive mode: 10k iterations, concurrency fuzzing enabled, potential deadlocks
+    // not treated as bugs (so the scheduler explores past suspected-but-legal lock inversions),
+    // and a longer deadlock timeout. Use for tests that pass under the default 100 iterations
+    // to widen the search space.
+    public static void RunAggressive(
+        Func<Task> testBody,
+        ITestOutputHelper output,
+        int iterations = 10_000)
+    {
+        CoyoteConfiguration config = CoyoteConfiguration.Create()
+            .WithTestingIterations((uint)iterations)
+            .WithSystematicFuzzingEnabled()
+            .WithPotentialDeadlocksReportedAsBugs(false)
+            .WithDeadlockTimeout(30_000)
+            .WithVerbosityEnabled()
+            .WithConsoleLoggingEnabled();
+
+        RunWithConfig(config, testBody, output, iterations);
+    }
+
+    private static void RunWithConfig(
+        CoyoteConfiguration config,
+        Func<Task> testBody,
+        ITestOutputHelper output,
+        int iterations)
+    {
         TestingEngine engine = TestingEngine.Create(config, testBody);
         engine.Run();
 

--- a/tests/Silverback.Tests.Concurrency/KafkaConcurrencyPatternCoyoteTests.cs
+++ b/tests/Silverback.Tests.Concurrency/KafkaConcurrencyPatternCoyoteTests.cs
@@ -1,0 +1,334 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using Shouldly;
+using Silverback.Messaging.Broker;
+using Silverback.Messaging.Broker.Kafka;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Silverback.Tests.Concurrency;
+
+// Kafka-specific concurrency tests targeting audit findings H5, H6, H7, and M2.
+//
+// H5, H6, and H7 are pattern-level tests: they extract the production code's
+// synchronization pattern into standalone code that Coyote can schedule, rather
+// than constructing the full KafkaConsumer / ConsumeLoopHandler with all their
+// dependencies. This means the tests document and catch the BUG PATTERN but do
+// not regression-protect the exact production class. When the pattern is fixed
+// in production, these tests should be updated to mirror the new pattern.
+//
+// M2 tests the real OffsetsTracker class (public, zero dependencies).
+public class KafkaConcurrencyPatternCoyoteTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public KafkaConcurrencyPatternCoyoteTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    // H5 — Kafka commit TOCTOU on revoked partitions.
+    //
+    // KafkaConsumer.CommitCoreAsync (lines 251-279) filters offsets by IsNotRevoked
+    // using a LINQ Where, then double-checks IsNotRevoked inside the loop body.
+    // Both checks read _revokedPartitions (ConcurrentDictionary) which is concurrently
+    // mutated by OnPartitionsRevoked from the rebalance callback thread.
+    //
+    // The TOCTOU window: a partition passes both checks, then gets revoked before
+    // StoreOffset runs. The stored offset is for a partition the consumer no longer
+    // owns, which violates exactly-once semantics.
+    //
+    // The test models the pattern: an enumerable filtered by "not revoked", a loop
+    // body that re-checks "not revoked" then stores, and a concurrent revoke task
+    // that adds to the revoked set. If Coyote interleaves the revoke between the
+    // inner check and the store, the invariant fires.
+    [Fact]
+    public void CommitCoreAsync_RevokeRacingCommit_ShouldNotStoreOffsetForRevokedPartition()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                ConcurrentDictionary<TopicPartition, byte> revokedPartitions = new();
+                TopicPartition tp0 = new("topic", new Partition(0));
+                TopicPartition tp1 = new("topic", new Partition(1));
+
+                List<TopicPartition> allPartitions = [tp0, tp1];
+                ConcurrentBag<TopicPartition> storedOffsets = new();
+
+                // T1: commit path — mirrors CommitCoreAsync lines 258-275
+                Task commit = Task.Run(
+                    async () =>
+                    {
+                        IEnumerable<TopicPartition> filtered = allPartitions
+                            .Where(tp => !revokedPartitions.ContainsKey(tp));
+
+                        foreach (TopicPartition tp in filtered)
+                        {
+                            await Task.Yield(); // scheduling point for Coyote
+
+                            if (!revokedPartitions.ContainsKey(tp)) // inner check (still TOCTOU)
+                            {
+                                await Task.Yield(); // one more point between check and store
+                                storedOffsets.Add(tp); // mirrors StoreOffset(...)
+                            }
+                        }
+                    });
+
+                // T2: revoke path — mirrors OnPartitionsRevoked adding to _revokedPartitions
+                Task revoke = Task.Run(
+                    async () =>
+                    {
+                        await Task.Yield();
+                        revokedPartitions.TryAdd(tp1, 0);
+                    });
+
+                await Task.WhenAll(commit, revoke).ConfigureAwait(false);
+
+                // Invariant: no stored offset should be for a partition that is now revoked.
+                foreach (TopicPartition stored in storedOffsets)
+                {
+                    revokedPartitions.ContainsKey(stored).ShouldBeFalse(
+                        $"Stored offset for revoked partition {stored}. " +
+                        "The TOCTOU window between IsNotRevoked check and StoreOffset " +
+                        "allowed a commit for a partition the consumer no longer owns. " +
+                        "See audit H5.");
+                }
+            },
+            _output);
+    }
+
+    // H6 — OnPartitionsRevoked commits after fire-and-forget consume-loop stop.
+    //
+    // KafkaConsumer.OnPartitionsRevoked (lines 152-174):
+    //   _consumeLoopHandler.StopAsync().FireAndForget();  // does NOT await
+    //   Task.WhenAll(...StopReadingAsync...).SafeWait();
+    //   if (!Configuration.EnableAutoCommit)
+    //       Client.Commit();
+    //
+    // The consume loop keeps running after StopAsync is fired-and-forgotten. It may
+    // consume and write messages into channels between the moment StopAsync is triggered
+    // and the moment Client.Commit() runs. Those messages are included in the committed
+    // offsets but were never fully processed, violating exactly-once semantics.
+    //
+    // The test models the pattern: a "stop" task that takes time to complete, a "commit"
+    // that runs before the stop finishes, and a "consume" task that produces work items
+    // in between. Assert: no work item is produced after commit.
+    [Fact]
+    public void OnPartitionsRevoked_CommitBeforeStopCompletes_ShouldNotCommitUnprocessedMessages()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                ConcurrentBag<string> consumed = new();
+                ConcurrentBag<string> committed = new();
+                SemaphoreSlim stopGate = new(0, 1);
+                bool stopRequested = false;
+                bool commitDone = false;
+
+                // Consume loop: keeps producing until stopped
+                Task consumeLoop = Task.Run(
+                    async () =>
+                    {
+                        int i = 0;
+                        while (!stopRequested)
+                        {
+                            consumed.Add($"msg-{i++}");
+                            await Task.Yield();
+                        }
+
+                        // The real consume loop doesn't stop instantly; it may
+                        // produce one more message after the flag is set.
+                        consumed.Add($"msg-{i}-after-stop");
+                    });
+
+                // Revoke handler pattern
+                Task revokeHandler = Task.Run(
+                    async () =>
+                    {
+                        // Fire-and-forget stop
+                        Task stopTask = Task.Run(
+                            async () =>
+                            {
+                                await stopGate.WaitAsync().ConfigureAwait(false);
+                                stopRequested = true;
+                            });
+                        // Do NOT await stopTask — fire and forget
+
+                        await Task.Yield(); // simulates StopReadingAsync().SafeWait()
+
+                        // Commit: snapshot whatever consumed is the "committed position"
+                        foreach (string msg in consumed)
+                        {
+                            committed.Add(msg);
+                        }
+
+                        commitDone = true;
+
+                        // Now release the stop gate so the consume loop eventually ends
+                        stopGate.Release();
+                        await stopTask.ConfigureAwait(false);
+                    });
+
+                await Task.WhenAll(consumeLoop, revokeHandler).ConfigureAwait(false);
+
+                // Invariant: everything committed should have been consumed BEFORE commit.
+                // Messages consumed AFTER commit are lost (committed offsets advanced past them
+                // but they were never processed).
+                // In this simplified model, the committed set was snapshotted from consumed,
+                // so the committed messages are a subset of consumed. But the consume loop may
+                // have added MORE messages after the snapshot, and those messages are "lost"
+                // because the committed offsets would include the produce-loop's latest position.
+                //
+                // The test checks: did the consume loop produce any message after commitDone
+                // was set? If so, the fire-and-forget pattern is unsound.
+                int consumedAfterCommit = consumed.Count - committed.Count;
+                consumedAfterCommit.ShouldBe(
+                    0,
+                    $"Consumed {consumedAfterCommit} message(s) after commit ran. " +
+                    "OnPartitionsRevoked fires StopAsync but does not await it, " +
+                    "then calls Client.Commit(). Messages consumed between the " +
+                    "fire-and-forget and the commit are included in the committed " +
+                    "offset position but were never fully processed. " +
+                    "See audit H6.");
+            },
+            _output);
+    }
+
+    // H7 — ConsumeLoopHandler.Start/Stop racy on non-volatile IsConsuming.
+    //
+    // ConsumeLoopHandler.Start() (lines 54-81):
+    //   if (IsConsuming) return;    // non-volatile read
+    //   IsConsuming = true;
+    //   Task.Factory.StartNew(...ConsumeAsync...).FireAndForget();
+    //
+    // Two concurrent Start() callers can both read IsConsuming=false and both
+    // start a consume loop. Two loops consuming from the same Confluent consumer
+    // causes undefined behavior (double-poll, offset confusion).
+    [Fact]
+    public void ConsumeLoopHandlerStart_ConcurrentCalls_ShouldStartExactlyOneLoop()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                bool isConsuming = false;
+                int loopsStarted = 0;
+
+                Task Start()
+                {
+                    // Mirrors ConsumeLoopHandler.Start() lines 58-81
+                    if (isConsuming)
+                        return Task.CompletedTask;
+
+                    isConsuming = true;
+
+                    Interlocked.Increment(ref loopsStarted);
+
+                    // Simulate Task.Factory.StartNew(ConsumeAsync).FireAndForget()
+                    Task.Run(
+                        async () =>
+                        {
+                            await Task.Yield(); // simulates the consume loop body
+                        }).FireAndForget();
+
+                    return Task.CompletedTask;
+                }
+
+                Task t1 = Task.Run(Start);
+                Task t2 = Task.Run(Start);
+
+                await Task.WhenAll(t1, t2).ConfigureAwait(false);
+                await Task.Yield(); // let fire-and-forget loops settle
+
+                loopsStarted.ShouldBe(
+                    1,
+                    $"Started {loopsStarted} consume loops instead of 1. " +
+                    "Two concurrent Start() calls both read IsConsuming=false " +
+                    "(non-volatile bool) and both started a loop. " +
+                    "See audit H7.");
+            },
+            _output);
+    }
+
+    // M2 — OffsetsTracker.TrackOffset performs two non-atomic AddOrUpdates.
+    //
+    // OffsetsTracker.TrackOffset (lines 27-42) updates _commitOffsets and
+    // _rollbackOffsets in two separate AddOrUpdate calls. A concurrent reader
+    // calling GetCommitOffsets() + GetRollbackOffsets() can observe a state
+    // where one dict has been updated but the other hasn't yet.
+    //
+    // The test writes offsets from one task while reading from another and
+    // checks that every partition visible in rollback offsets is also visible
+    // in commit offsets (they should always appear as a pair since TrackOffset
+    // writes both).
+    [Fact]
+    public void OffsetsTracker_ConcurrentTrackAndRead_ShouldNotObservePartialState()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                OffsetsTracker tracker = new();
+                TopicPartition tp = new("topic", new Partition(0));
+                bool observedPartialState = false;
+
+                // T1: repeatedly track offsets
+                Task writer = Task.Run(
+                    async () =>
+                    {
+                        for (int i = 0; i < 10; i++)
+                        {
+                            tracker.TrackOffset(new KafkaOffset(tp, new Offset(i)));
+                            await Task.Yield();
+                        }
+                    });
+
+                // T2: repeatedly read both dicts and check consistency
+                Task reader = Task.Run(
+                    async () =>
+                    {
+                        for (int i = 0; i < 10; i++)
+                        {
+                            var commits = tracker.GetCommitOffsets();
+                            await Task.Yield(); // scheduling point between the two reads
+                            var rollbacks = tracker.GetRollbackOffSets();
+
+                            // If rollbacks has a key that commits doesn't, the reader
+                            // observed a partial state (second AddOrUpdate ran before first).
+                            // Vice versa is also partial but less likely to cause issues.
+                            foreach (KafkaOffset rb in rollbacks)
+                            {
+                                if (!commits.Any(c => c.TopicPartition == rb.TopicPartition))
+                                {
+                                    observedPartialState = true;
+                                }
+                            }
+
+                            await Task.Yield();
+                        }
+                    });
+
+                await Task.WhenAll(writer, reader).ConfigureAwait(false);
+
+                observedPartialState.ShouldBeFalse(
+                    "Reader observed a partition in rollback offsets that was absent from " +
+                    "commit offsets. OffsetsTracker.TrackOffset performs two sequential " +
+                    "AddOrUpdate calls that are not atomic as a pair. " +
+                    "See audit M2.");
+            },
+            _output);
+    }
+}
+
+// Minimal extension to mirror Silverback.Util.TaskExtensions.FireAndForget,
+// which is internal. The Coyote rewriter intercepts Task.Run and scheduling;
+// the extension itself just suppresses the compiler warning.
+file static class FireAndForgetExtensions
+{
+    public static void FireAndForget(this Task task) => _ = task;
+}

--- a/tests/Silverback.Tests.Concurrency/KafkaConcurrencyPatternCoyoteTests.cs
+++ b/tests/Silverback.Tests.Concurrency/KafkaConcurrencyPatternCoyoteTests.cs
@@ -256,6 +256,54 @@ public class KafkaConcurrencyPatternCoyoteTests
             _output);
     }
 
+    // H7 aggressive — same pattern as above but with Task.Yield() inserted
+    // between the check and the set to give Coyote an explicit scheduling point.
+    // The default 100-iteration run passes because the check-then-act is
+    // synchronous with no yield between the two statements. The aggressive
+    // variant proves the pattern is unsafe by widening the race window to a
+    // point Coyote can schedule.
+    [Fact]
+    public void ConsumeLoopHandlerStart_ConcurrentCalls_Aggressive_ShouldStartExactlyOneLoop()
+    {
+        CoyoteTestRunner.RunAggressive(
+            async () =>
+            {
+                bool isConsuming = false;
+                int loopsStarted = 0;
+
+                async Task Start()
+                {
+                    if (isConsuming)
+                        return;
+
+                    await Task.Yield(); // scheduling point at the race window
+
+                    isConsuming = true;
+                    Interlocked.Increment(ref loopsStarted);
+
+                    Task.Run(
+                        async () =>
+                        {
+                            await Task.Yield();
+                        }).FireAndForget();
+                }
+
+                Task t1 = Task.Run(Start);
+                Task t2 = Task.Run(Start);
+
+                await Task.WhenAll(t1, t2).ConfigureAwait(false);
+                await Task.Yield();
+
+                loopsStarted.ShouldBe(
+                    1,
+                    $"Started {loopsStarted} consume loops instead of 1. " +
+                    "Two concurrent Start() calls both read IsConsuming=false " +
+                    "and both started a loop. See audit H7.");
+            },
+            _output,
+            iterations: 1_000);
+    }
+
     // M2 — OffsetsTracker.TrackOffset performs two non-atomic AddOrUpdates.
     //
     // OffsetsTracker.TrackOffset (lines 27-42) updates _commitOffsets and

--- a/tests/Silverback.Tests.Concurrency/MessageStreamProviderCoyoteTests.cs
+++ b/tests/Silverback.Tests.Concurrency/MessageStreamProviderCoyoteTests.cs
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System.Reflection;
+using System.Threading.Tasks;
+using Shouldly;
+using Silverback.Messaging.Messages;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Silverback.Tests.Concurrency;
+
+// Audit findings C2 and H4 — both rooted in MessageStreamProvider<T>.
+//
+// C2: Abort() and CompleteAsync() are not safe to call concurrently. The audit
+//     predicted a silent no-op via the early-return guard
+//         if (_isAborting || _isCompleting) return;
+//     but there is also a second, orthogonal failure mode: once CompleteAsync
+//     has finished and `_completed = true`, a subsequent Abort() reaches the
+//     line `if (_completed) throw new InvalidOperationException(...)` and
+//     throws. Both manifestations violate the invariant "Abort() called
+//     concurrently with an in-flight CompleteAsync() must either wait for
+//     the complete then observe the completed state, or actually abort the
+//     streams; it must never silently no-op and must never throw." Coyote
+//     catches whichever manifestation its scheduler hits first — in this
+//     repo it lands on the throw variant within a few iterations.
+//
+// H4: _lazyStreams is added to under `lock (_lazyStreams)` but read without
+//     the lock in StreamsCount, Abort, CompleteAsync, and PushToCompatibleStreams.
+//     Racing CreateStream() against PushAsync() can therefore either throw
+//     from the enumerator version check or silently drop the newly added
+//     stream from a push.
+//
+// Both tests currently fail on master. Fix directions tracked in the audit;
+// broadly: replace the re-entry guard in Abort/CompleteAsync with a proper
+// wait-then-observe pattern, and read _lazyStreams only under the lock (or
+// switch to a ConcurrentBag/ImmutableArray<T>).
+public class MessageStreamProviderCoyoteTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public MessageStreamProviderCoyoteTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    // C2
+    [Fact]
+    public void Abort_RacingCompleteAsync_ShouldNotReturnAsSilentNoOp()
+    {
+        // Race CompleteAsync() against Abort() on an otherwise-idle MessageStreamProvider.
+        // The provider has no lazy streams, so CompleteAsync's ParallelForEachAsync body is
+        // essentially empty, but the method still runs through its guard:
+        //
+        //   1. early-return if (_isCompleting || _isAborting) return;
+        //   2. await _completeSemaphore.WaitAsync(cancellationToken);
+        //   3. try { ... _isCompleting = true; ... _completed = true; }
+        //      finally { _isCompleting = false; _completeSemaphore.Release(); }
+        //
+        // The symmetric Abort() has the same guard. If Coyote interleaves Abort() between
+        // steps 3's `_isCompleting = true` and the finally's reset, Abort falls into the
+        // early-return and silently no-ops: neither `_aborted` nor `_completed` is true
+        // at the moment Abort returns, even though the caller explicitly asked to abort.
+        //
+        // We snapshot the private `_aborted` / `_completed` fields via reflection immediately
+        // after Abort returns and assert that at least one of them is true. Reflection is
+        // used because the fields are `private`; `InternalsVisibleTo` only opens `internal`.
+        //
+        // Currently fails on master. Fix direction (audit C2): replace the re-entry guard
+        // with a proper wait-then-observe pattern so a losing racer either waits for the
+        // in-progress operation or actually performs its work.
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                MessageStreamProvider<string> provider = new();
+
+                Task producer = Task.Run(
+                    async () => await provider.CompleteAsync().ConfigureAwait(false));
+
+                bool abortObservedTerminalState = true;
+                Task aborter = Task.Run(
+                    () =>
+                    {
+                        provider.Abort();
+                        abortObservedTerminalState = ReadTerminalFlags(provider);
+                    });
+
+                await Task.WhenAll(producer, aborter).ConfigureAwait(false);
+
+                abortObservedTerminalState.ShouldBeTrue(
+                    "MessageStreamProvider.Abort() returned while _isCompleting was set, " +
+                    "leaving the provider in neither _aborted nor _completed state. " +
+                    "Caller asked to abort but Abort silently no-opped on cross-thread reentry. " +
+                    "See audit finding C2.");
+            },
+            _output);
+    }
+
+    private static bool ReadTerminalFlags(MessageStreamProvider<string> provider)
+    {
+        System.Type type = typeof(MessageStreamProvider<string>);
+        bool aborted = (bool)type
+            .GetField("_aborted", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(provider)!;
+        bool completed = (bool)type
+            .GetField("_completed", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(provider)!;
+        return aborted || completed;
+    }
+
+    // H4 — deferred for this batch. The enumerator path inside MessageStreamEnumerable<T>
+    // interacts with Coyote's rewritten AsyncTaskMethodBuilder in a way that crashes the
+    // test host (double SetResult). Needs investigation. Left as [Fact(Skip=...)] so it
+    // shows up in the report; un-skip once the rewriter interaction is understood or the
+    // test is restructured to avoid await foreach.
+    [Fact(Skip = "Coyote rewriter interaction with MessageStreamEnumerable async enumerator; see audit H4 follow-up")]
+    public void CreateStream_RacingPushAsync_ShouldNeitherThrowNorDropTheNewStream()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                MessageStreamProvider<string> provider = new();
+
+                // Pre-create one stream so _lazyStreams starts non-empty and PushToCompatibleStreams
+                // actually iterates something.
+                IMessageStreamEnumerable<string> first = provider.CreateStream<string>();
+                Task drainFirst = Task.Run(
+                    async () =>
+                    {
+                        try
+                        {
+                            await foreach (string msg in first.ConfigureAwait(false))
+                            {
+                                _ = msg;
+                                await Task.Yield();
+                            }
+                        }
+                        catch
+                        {
+                            // swallow abort/complete exceptions
+                        }
+                    });
+
+                // T1: keep pushing while T2 adds a second stream.
+                Task pushing = Task.Run(
+                    async () => await provider.PushAsync("msg").ConfigureAwait(false));
+
+                IMessageStreamEnumerable<string>? second = null;
+                Task adding = Task.Run(
+                    () =>
+                    {
+                        second = provider.CreateStream<string>();
+                    });
+
+                await Task.WhenAll(pushing, adding).ConfigureAwait(false);
+
+                // Cleanly tear down so drainFirst completes.
+                await provider.CompleteAsync().ConfigureAwait(false);
+                await drainFirst.ConfigureAwait(false);
+
+                second.ShouldNotBeNull();
+            },
+            _output);
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/MqttConcurrencyPatternCoyoteTests.cs
+++ b/tests/Silverback.Tests.Concurrency/MqttConcurrencyPatternCoyoteTests.cs
@@ -278,4 +278,75 @@ public class MqttConcurrencyPatternCoyoteTests
             },
             _output);
     }
+
+    // MC5 — ConsumedApplicationMessage TaskCompletionSource reassignment race.
+    //
+    // ConsumerChannelsManager.cs:69-73 (MQTT):
+    //   if (await consumedMessage.TaskCompletionSource.Task)
+    //       break;
+    //   consumedMessage.TaskCompletionSource = new TaskCompletionSource<bool>();
+    //
+    // MqttConsumer.cs:164,171:
+    //   consumedMessage.TaskCompletionSource.SetResult(true);   // commit
+    //   consumedMessage?.TaskCompletionSource.SetResult(false); // rollback
+    //
+    // After the channel reader awaits the TCS, it reassigns a new TCS. But
+    // CommitCoreAsync/RollbackCoreAsync may still hold the OLD TCS reference
+    // and call SetResult on it. The new TCS is never signaled, so the channel
+    // reader blocks forever waiting for the commit/rollback ack that was sent
+    // to a dead TCS.
+    [Fact]
+    public void MqttConsumedMessage_TcsReassignment_ShouldNotLoseSignal()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                TaskCompletionSource<bool> tcs = new();
+                bool signalReceived = false;
+
+                // T1: channel reader — await, then reassign TCS
+                Task channelReader = Task.Run(
+                    async () =>
+                    {
+                        // First await returns false (rollback), so loop continues
+                        bool shouldBreak = await tcs.Task.ConfigureAwait(false);
+                        if (shouldBreak) return;
+
+                        // Reassign — mirrors line 73
+                        tcs = new TaskCompletionSource<bool>();
+
+                        // Await again for the next commit/rollback signal
+                        bool result = await tcs.Task.ConfigureAwait(false);
+                        signalReceived = true;
+                    });
+
+                // T2: commit path — sets result on the TCS reference it holds.
+                // If T1 reassigned between T2 capturing the ref and T2 calling SetResult,
+                // T2 sets the OLD tcs (already completed) and the NEW tcs is never signaled.
+                await Task.Yield();
+
+                // First signal: rollback (false) — wakes up T1's first await
+                TaskCompletionSource<bool> capturedTcs = tcs;
+                capturedTcs.SetResult(false);
+
+                await Task.Yield();
+
+                // Second signal: commit (true) — should wake T1's second await
+                // But if T1 already reassigned tcs, capturedTcs2 points to the OLD one
+                TaskCompletionSource<bool> capturedTcs2 = tcs;
+                await Task.Yield();
+                capturedTcs2.SetResult(true);
+
+                // Give channelReader time to complete
+                Task finished = await Task.WhenAny(channelReader, Task.Delay(2000)).ConfigureAwait(false);
+
+                finished.ShouldBe(
+                    channelReader,
+                    "Channel reader blocked forever. The commit signal was sent to " +
+                    "a stale TaskCompletionSource that was already completed. The new " +
+                    "TCS created by the channel reader was never signaled. " +
+                    "See finding MC5 / MQTT ConsumerChannelsManager:73.");
+            },
+            _output);
+    }
 }

--- a/tests/Silverback.Tests.Concurrency/MqttConcurrencyPatternCoyoteTests.cs
+++ b/tests/Silverback.Tests.Concurrency/MqttConcurrencyPatternCoyoteTests.cs
@@ -224,6 +224,47 @@ public class MqttConcurrencyPatternCoyoteTests
             _output);
     }
 
+    // MC3 aggressive — same TOCTOU pattern with Task.Yield() at the race point.
+    [Fact]
+    public void PendingReconnect_ConcurrentTryConnect_Aggressive_ShouldReconnectExactlyOnce()
+    {
+        CoyoteTestRunner.RunAggressive(
+            async () =>
+            {
+                bool mqttClientWasConnected = true;
+                bool pendingReconnect = false;
+                int reconnectCount = 0;
+
+                async Task TryConnect()
+                {
+                    if (mqttClientWasConnected)
+                    {
+                        await Task.Yield(); // scheduling point at the race window
+                        pendingReconnect = true;
+                        mqttClientWasConnected = false;
+                    }
+
+                    if (pendingReconnect)
+                    {
+                        await Task.Yield(); // scheduling point
+                        pendingReconnect = false;
+                        Interlocked.Increment(ref reconnectCount);
+                    }
+                }
+
+                Task t1 = Task.Run(TryConnect);
+                Task t2 = Task.Run(TryConnect);
+
+                await Task.WhenAll(t1, t2).ConfigureAwait(false);
+
+                reconnectCount.ShouldBe(
+                    1,
+                    $"Reconnect executed {reconnectCount} times instead of 1. See MC3.");
+            },
+            _output,
+            iterations: 1_000);
+    }
+
     // MC4 — channel.Reset() racing with OnMessageReceivedAsync.
     //
     // ConsumerChannelsManager.OnMessageReceivedAsync (lines 87-88):
@@ -277,6 +318,58 @@ public class MqttConcurrencyPatternCoyoteTests
                     "replaced. See MC4.");
             },
             _output);
+    }
+
+    // MC4 aggressive — same pattern with Task.Yield() between check and reset.
+    [Fact]
+    public void ChannelReset_ConcurrentWithWrite_Aggressive_ShouldNotLoseMessages()
+    {
+        CoyoteTestRunner.RunAggressive(
+            async () =>
+            {
+                Channel<string> channel = Channel.CreateBounded<string>(10);
+                channel.Writer.Complete();
+                bool isCompleted = true;
+                ConcurrentBag<string> written = new();
+
+                async Task OnMessageReceived(string message)
+                {
+                    if (isCompleted)
+                    {
+                        await Task.Yield(); // scheduling point at the race window
+                        channel = Channel.CreateBounded<string>(10);
+                        isCompleted = false;
+                    }
+
+                    await Task.Yield(); // between reset and write
+
+                    bool success = channel.Writer.TryWrite(message);
+                    if (success)
+                        written.Add(message);
+                }
+
+                Task[] tasks = Enumerable.Range(0, 4)
+                    .Select(i => Task.Run(async () => await OnMessageReceived($"msg-{i}").ConfigureAwait(false)))
+                    .ToArray();
+
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+
+                // The real bug: messages end up in orphaned channels that got replaced.
+                // TryWrite "succeeds" on any channel, but the replaced channel is never
+                // read. Count messages in the FINAL channel to detect the loss.
+                int readable = 0;
+                while (channel.Reader.TryRead(out _))
+                    readable++;
+
+                readable.ShouldBe(
+                    4,
+                    $"Only {readable}/4 messages in the final channel. " +
+                    "Concurrent OnMessageReceivedAsync callbacks each created their own " +
+                    "channel via Reset; messages written to replaced channels are lost. " +
+                    "See MC4.");
+            },
+            _output,
+            iterations: 1_000);
     }
 
     // MC5 — ConsumedApplicationMessage TaskCompletionSource reassignment race.

--- a/tests/Silverback.Tests.Concurrency/MqttConcurrencyPatternCoyoteTests.cs
+++ b/tests/Silverback.Tests.Concurrency/MqttConcurrencyPatternCoyoteTests.cs
@@ -1,0 +1,281 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Silverback.Tests.Concurrency;
+
+// MQTT-specific concurrency tests targeting bugs found in the MQTT integration.
+//
+// All tests are pattern-level: they extract the production code's synchronization
+// pattern into standalone code that Coyote can schedule. The MQTT classes
+// (ConsumerChannelsManager, MqttClientWrapper) are internal with complex
+// dependencies, so pattern tests are the pragmatic choice.
+//
+// MC1: _nextChannelIndex++ non-atomic increment in OnMessageReceivedAsync
+// MC2: _publishQueueChannel recreation race (check-then-create)
+// MC3: _pendingReconnect / _mqttClientWasConnected TOCTOU on non-volatile bools
+// MC4: channel.Reset() racing with OnMessageReceivedAsync after reconnect
+public class MqttConcurrencyPatternCoyoteTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public MqttConcurrencyPatternCoyoteTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    // MC1 — _nextChannelIndex++ non-atomic increment.
+    //
+    // ConsumerChannelsManager.OnMessageReceivedAsync (line 84):
+    //   ConsumerChannel channel = _channels[_nextChannelIndex++];
+    //
+    // MQTTnet fires OnMessageReceivedAsync on arbitrary ThreadPool threads.
+    // Two concurrent callbacks can both read the same index value, route
+    // messages to the same channel, and lose an increment. With N channels,
+    // some channels get double-fed while others starve.
+    //
+    // Additionally line 92 has a redundant modular write:
+    //   _nextChannelIndex = (_nextChannelIndex + 1) % _channels.Length;
+    // which compounds the race (the ++ at line 84 and the modular write at
+    // line 92 both modify the same field).
+    [Fact]
+    public void NextChannelIndex_ConcurrentIncrements_ShouldDistributeEvenly()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                const int channelCount = 4;
+                int nextChannelIndex = 0;
+                int[] channelHits = new int[channelCount];
+
+                // Mirrors OnMessageReceivedAsync: read index, route, increment.
+                // Production code: _channels[_nextChannelIndex++]
+                // then: _nextChannelIndex = (_nextChannelIndex + 1) % _channels.Length
+                void RouteMessage()
+                {
+                    int index = nextChannelIndex; // non-atomic read
+                    Interlocked.Increment(ref channelHits[index % channelCount]);
+                    nextChannelIndex = (index + 1) % channelCount; // non-atomic write
+                }
+
+                // Simulate 8 concurrent MQTTnet message-received callbacks
+                Task[] callbacks = Enumerable.Range(0, 8)
+                    .Select(_ => Task.Run(RouteMessage))
+                    .ToArray();
+
+                await Task.WhenAll(callbacks).ConfigureAwait(false);
+
+                // Invariant: total hits must equal total messages.
+                int totalHits = channelHits.Sum();
+                totalHits.ShouldBe(8, "Lost message routing due to _nextChannelIndex race.");
+
+                // Stricter: no channel should get 0 hits if messages >= channels.
+                // With 8 messages and 4 channels, each channel should get 2 in the
+                // non-racy case. Any channel with 0 hits means the round-robin broke.
+                for (int i = 0; i < channelCount; i++)
+                {
+                    channelHits[i].ShouldBeGreaterThan(
+                        0,
+                        $"Channel {i} received 0 messages out of 8. " +
+                        "The non-atomic _nextChannelIndex++ in OnMessageReceivedAsync " +
+                        "caused multiple callbacks to read the same index, skipping " +
+                        "this channel entirely. See MC1.");
+                }
+            },
+            _output);
+    }
+
+    // MC2 — _publishQueueChannel recreation race.
+    //
+    // MqttClientWrapper.ConnectCoreAsync (lines 113-114):
+    //   if (_publishQueueChannel.Reader.Completion.IsCompleted)
+    //       _publishQueueChannel = Channel.CreateUnbounded<QueuedMessage>();
+    //
+    // If ProcessPublishQueueAsync is still draining the old channel while
+    // ConnectCoreAsync recreates it, the old channel reference held by the
+    // drainer becomes stale. Messages written to the new channel are never
+    // read; messages the drainer reads from the old channel are for the
+    // previous session. No synchronization between disconnect + reconnect.
+    [Fact]
+    public void PublishQueueChannel_RecreationDuringDrain_ShouldNotLoseMessages()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                Channel<string> publishChannel = Channel.CreateUnbounded<string>();
+                ConcurrentBag<string> drained = new();
+
+                // T1: drainer (mirrors ProcessPublishQueueAsync) — holds old channel ref
+                Channel<string> drainerRef = publishChannel;
+                Task drainer = Task.Run(
+                    async () =>
+                    {
+                        await foreach (string msg in drainerRef.Reader.ReadAllAsync().ConfigureAwait(false))
+                        {
+                            drained.Add(msg);
+                            await Task.Yield();
+                        }
+                    });
+
+                // Write a message to the current channel
+                await publishChannel.Writer.WriteAsync("msg-1").ConfigureAwait(false);
+                await Task.Yield();
+
+                // T2: reconnect path — check-then-recreate (mirrors ConnectCoreAsync)
+                Task reconnect = Task.Run(
+                    () =>
+                    {
+                        // This is the racy pattern: check completion, then replace
+                        if (!publishChannel.Reader.Completion.IsCompleted)
+                        {
+                            publishChannel.Writer.Complete(); // complete old
+                        }
+
+                        publishChannel = Channel.CreateUnbounded<string>(); // replace
+                    });
+
+                await reconnect.ConfigureAwait(false);
+
+                // Write to the NEW channel — drainer still reads from the OLD one
+                await publishChannel.Writer.WriteAsync("msg-2").ConfigureAwait(false);
+                publishChannel.Writer.Complete();
+
+                // Give drainer time to finish the old channel
+                await drainer.ConfigureAwait(false);
+
+                // Invariant: drainer should have seen ALL messages. But msg-2 was written
+                // to the new channel while the drainer holds the old reference.
+                drained.Count.ShouldBe(
+                    2,
+                    $"Drainer only saw {drained.Count}/2 messages. " +
+                    "The channel was recreated without redirecting the drainer to the " +
+                    "new instance. Messages written after reconnect are lost. See MC2.");
+            },
+            _output);
+    }
+
+    // MC3 — _pendingReconnect / _mqttClientWasConnected TOCTOU.
+    //
+    // MqttClientWrapper.TryConnectAsync (lines 168-183):
+    //   if (_mqttClientWasConnected)      // non-volatile read
+    //   {
+    //       _pendingReconnect = true;     // non-volatile write
+    //       _mqttClientWasConnected = false;
+    //   }
+    //   if (_pendingReconnect)            // non-volatile read
+    //   {
+    //       _pendingReconnect = false;    // non-volatile write
+    //   }
+    //
+    // These bools are read/written from the background ConnectAndKeepConnectionAlive
+    // task and can be indirectly affected by disconnect events on the MQTTnet thread.
+    // Two concurrent calls to TryConnectAsync can both read _mqttClientWasConnected=true
+    // and both set _pendingReconnect=true, then both read _pendingReconnect=true and
+    // both execute the reconnect logic.
+    [Fact]
+    public void PendingReconnect_ConcurrentTryConnect_ShouldReconnectExactlyOnce()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                bool mqttClientWasConnected = true;
+                bool pendingReconnect = false;
+                int reconnectCount = 0;
+
+                Task TryConnect()
+                {
+                    // Mirrors TryConnectAsync lines 168-183
+                    if (mqttClientWasConnected)
+                    {
+                        pendingReconnect = true;
+                        mqttClientWasConnected = false;
+                    }
+
+                    if (pendingReconnect)
+                    {
+                        pendingReconnect = false;
+                        Interlocked.Increment(ref reconnectCount);
+                    }
+
+                    return Task.CompletedTask;
+                }
+
+                Task t1 = Task.Run(TryConnect);
+                Task t2 = Task.Run(TryConnect);
+
+                await Task.WhenAll(t1, t2).ConfigureAwait(false);
+
+                reconnectCount.ShouldBe(
+                    1,
+                    $"Reconnect executed {reconnectCount} times instead of 1. " +
+                    "Two concurrent TryConnectAsync calls both read " +
+                    "_mqttClientWasConnected=true (non-volatile) and both triggered " +
+                    "the reconnect path. See MC3.");
+            },
+            _output);
+    }
+
+    // MC4 — channel.Reset() racing with OnMessageReceivedAsync.
+    //
+    // ConsumerChannelsManager.OnMessageReceivedAsync (lines 87-88):
+    //   if (channel.IsCompleted)
+    //       channel.Reset();
+    //
+    // After a reconnect, channels may be marked completed. The next message
+    // callback checks IsCompleted and calls Reset(). But another callback
+    // may also see IsCompleted=true for the same channel and call Reset()
+    // concurrently, or a third callback may try to Write to a channel that
+    // is mid-Reset.
+    [Fact]
+    public void ChannelReset_ConcurrentWithWrite_ShouldNotLoseMessages()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                Channel<string> channel = Channel.CreateBounded<string>(10);
+                channel.Writer.Complete(); // simulate "completed after disconnect"
+                bool isCompleted = true;
+                ConcurrentBag<string> written = new();
+
+                async Task OnMessageReceived(string message)
+                {
+                    // Mirrors OnMessageReceivedAsync lines 87-92
+                    if (isCompleted)
+                    {
+                        channel = Channel.CreateBounded<string>(10); // Reset
+                        isCompleted = false;
+                    }
+
+                    bool success = channel.Writer.TryWrite(message);
+                    if (success)
+                        written.Add(message);
+
+                    await Task.Yield();
+                }
+
+                // Two callbacks racing after reconnect
+                Task t1 = Task.Run(async () => await OnMessageReceived("msg-1").ConfigureAwait(false));
+                Task t2 = Task.Run(async () => await OnMessageReceived("msg-2").ConfigureAwait(false));
+
+                await Task.WhenAll(t1, t2).ConfigureAwait(false);
+
+                written.Count.ShouldBe(
+                    2,
+                    $"Only {written.Count}/2 messages written after reconnect. " +
+                    "Concurrent OnMessageReceivedAsync callbacks both saw " +
+                    "IsCompleted=true, both called Reset (creating two channels), " +
+                    "and one message was written to a channel that was immediately " +
+                    "replaced. See MC4.");
+            },
+            _output);
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/SequenceAbortCoyoteTests.cs
+++ b/tests/Silverback.Tests.Concurrency/SequenceAbortCoyoteTests.cs
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System;
+using System.Threading.Tasks;
+using Shouldly;
+using Silverback.Messaging.Broker.Behaviors;
+using Silverback.Messaging.Sequences;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Silverback.Tests.Concurrency;
+
+// Systematic concurrency tests for SequenceBase<TEnvelope> completion / abort synchronization,
+// executed under the Microsoft Coyote scheduler.
+//
+// Each [Fact] wraps a self-contained async test body in Coyote's TestingEngine, which explores
+// different interleavings of the Task-based plumbing. A run is considered successful if no bug
+// is found across all scheduled iterations; otherwise we fail the xunit test and emit Coyote's
+// replay report (which includes a deterministic schedule to reproduce the bug).
+//
+// The assemblies under test (Silverback.Core, Silverback.Integration, and this test DLL) are
+// binary-rewritten by `coyote rewrite` as a post-build step in the .csproj so that async
+// state machines, SemaphoreSlim, Task.Run, etc. are intercepted by Coyote.
+public class SequenceAbortCoyoteTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public SequenceAbortCoyoteTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void ConcurrentAbort_ShouldReachAbortedStateExactlyOnce()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
+                using TestSequence sequence = new("seq-concurrent-abort", context);
+
+                Task abort1 = sequence.AbortAsync(SequenceAbortReason.IncompleteSequence);
+                Task abort2 = sequence.AbortAsync(SequenceAbortReason.IncompleteSequence);
+                Task abort3 = sequence.AbortAsync(SequenceAbortReason.IncompleteSequence);
+
+                await Task.WhenAll(abort1, abort2, abort3).ConfigureAwait(false);
+
+                // Invariants: once any abort has returned, the sequence must be consistently
+                // aborted; it must never be pending, and the abort reason must be the one we
+                // requested (no spurious upgrade from the idempotent path).
+                sequence.IsAborted.ShouldBeTrue();
+                sequence.IsPending.ShouldBeFalse();
+                sequence.AbortReason.ShouldBe(SequenceAbortReason.IncompleteSequence);
+            },
+            _output);
+    }
+
+    [Fact]
+    public void AbortThenAbortIfIncomplete_ShouldBothReturnAndRemainAborted()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
+                using TestSequence sequence = new("seq-abort-plus-abort-if-incomplete", context);
+
+                Task abort = sequence.AbortAsync(SequenceAbortReason.Error, new InvalidOperationException("boom"));
+                Task abortIfIncomplete = sequence.AbortIfIncompleteAsync();
+
+                await Task.WhenAll(abort, abortIfIncomplete).ConfigureAwait(false);
+
+                // The first abort carries the higher-priority reason (Error) and must win.
+                // AbortIfIncompleteAsync racing against it must not downgrade the reason nor
+                // leave the sequence in a partially-aborted state.
+                sequence.IsAborted.ShouldBeTrue();
+                sequence.IsPending.ShouldBeFalse();
+                sequence.AbortReason.ShouldBe(SequenceAbortReason.Error);
+            },
+            _output);
+    }
+
+    [Fact]
+    public void ConcurrentAbortMix_ShouldConvergeToSingleAbortedStateWithoutSemaphoreLeak()
+    {
+        // Three concurrent tasks: two AbortAsync(IncompleteSequence) and one AbortIfIncompleteAsync.
+        // This mixes the two code paths that both take _completeSemaphoreSlim, so any
+        // release-path asymmetry (such as the bug we found and fixed in AbortIfIncompleteAsync)
+        // will manifest as either a deadlock or a stuck semaphore that Dispose() then hits.
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
+                using TestSequence sequence = new("seq-abort-mix", context);
+
+                Task abort1 = sequence.AbortAsync(SequenceAbortReason.IncompleteSequence);
+                Task abort2 = sequence.AbortAsync(SequenceAbortReason.IncompleteSequence);
+                Task abortIfIncomplete = sequence.AbortIfIncompleteAsync();
+
+                await Task.WhenAll(abort1, abort2, abortIfIncomplete).ConfigureAwait(false);
+
+                sequence.IsAborted.ShouldBeTrue();
+                sequence.IsPending.ShouldBeFalse();
+                sequence.AbortReason.ShouldBe(SequenceAbortReason.IncompleteSequence);
+            },
+            _output);
+    }
+
+    [Fact]
+    public void ConcurrentErrorAborts_ShouldSetAbortExceptionExactlyOnce()
+    {
+        // Two concurrent AbortAsync(Error, ...) calls. The first to acquire _completeSemaphoreSlim
+        // should set AbortException; the second should observe IsAborted, wait on
+        // _abortingTaskCompletionSource, and return. AbortException must be exactly one of the two
+        // exceptions we passed in — no null, no partial state.
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
+                using TestSequence sequence = new("seq-concurrent-error", context);
+
+                InvalidOperationException ex1 = new("first");
+                InvalidOperationException ex2 = new("second");
+
+                Task abort1 = sequence.AbortAsync(SequenceAbortReason.Error, ex1);
+                Task abort2 = sequence.AbortAsync(SequenceAbortReason.Error, ex2);
+
+                await Task.WhenAll(abort1, abort2).ConfigureAwait(false);
+
+                sequence.IsAborted.ShouldBeTrue();
+                sequence.AbortReason.ShouldBe(SequenceAbortReason.Error);
+                sequence.AbortException.ShouldNotBeNull();
+                Exception abortException = sequence.AbortException;
+                (abortException == ex1 || abortException == ex2).ShouldBeTrue(
+                    "AbortException must be one of the exceptions that was passed in, not a wrapper or null.");
+            },
+            _output);
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/SequenceAddCompleteRaceCoyoteTests.cs
+++ b/tests/Silverback.Tests.Concurrency/SequenceAddCompleteRaceCoyoteTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System;
+using System.Threading.Tasks;
+using Silverback.Messaging.Broker.Behaviors;
+using Silverback.Messaging.Sequences;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Silverback.Tests.Concurrency;
+
+// Audit finding C1 — AddCoreAsync's call to CompleteCoreAsync is not serialized with
+// AbortCoreAsync. See src/Silverback.Integration/Messaging/Sequences/SequenceBase`1.cs.
+//
+//   - AddCoreAsync at line 399 calls the private CompleteCoreAsync while holding ONLY
+//     _addSemaphoreSlim.
+//   - The public CompleteAsync wrapper (line 426) wraps CompleteCoreAsync under
+//     _completeSemaphoreSlim.
+//   - AbortAsync (line 276) wraps AbortCoreAsync under _completeSemaphoreSlim.
+//
+// Because the AddAsync path to CompleteCoreAsync bypasses _completeSemaphoreSlim,
+// a concurrent AbortAsync can enter AbortCoreAsync, set _completeState = Aborted,
+// call _streamProvider.AbortIfPending (which under the C2 bug may silently no-op),
+// wait on _addSemaphoreSlim (held by the Add path), and then after Add releases the
+// semaphore run its rollback / error-policy logic against a batch whose
+// _streamProvider.CompleteAsync has already returned.
+//
+// The Add path's CompleteCoreAsync also writes _completeState = Complete at the end,
+// overwriting the Aborted value — so the final state is Complete AND the error
+// policy has been invoked. The invariant the audit names is: "if IsComplete == true
+// then AbortReason == None AND no rollback / error-policy call was made. Symmetrically,
+// if IsAborted == true then no NotifyProcessingCompleted was sent to downstream as
+// success."
+//
+// This test reproduces the race at the primitive level by invoking CompleteCoreAsync
+// directly (via reflection on a TestSequence) while holding only _addSemaphoreSlim,
+// then racing it against AbortAsync. We assert the primary terminal invariant:
+// once both tasks have returned, IsComplete and IsAborted must not both be true, and
+// the single _completeState value must match one of IsComplete or IsAborted.
+//
+// Because _completeState is a single int field, Complete XOR Aborted holds as a raw
+// state invariant even when the race fires; the actual corruption shows up as
+// downstream exceptions (stream provider in both completed and aborted state) or
+// as inconsistent side effects. We widen the assertion by also checking that the
+// test ran to completion without any unhandled exceptions — Coyote reports any
+// unhandled exception as a bug.
+//
+// Currently expected to fail on master. Fix direction (audit C1): either acquire
+// _completeSemaphoreSlim inside AddCoreAsync before calling CompleteCoreAsync, or
+// have AbortCoreAsync re-check _completeState under _addSemaphoreSlim before its
+// own state write.
+public class SequenceAddCompleteRaceCoyoteTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public SequenceAddCompleteRaceCoyoteTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    // Currently skipped: the default Coyote runner reports the race as a "potential
+    // deadlock or hang" before it explores a path that reaches a concrete assertion
+    // failure. The deadlock detector triggers on the legitimate inversion between
+    //   - T1 holding _addSemaphoreSlim while awaiting _streamProvider.CompleteAsync
+    //   - T2 holding _completeSemaphoreSlim while awaiting _addSemaphoreSlim
+    // The scheduling that resolves the inversion (T1's provider.CompleteAsync throws
+    // "already aborted" because T2's AbortIfPending ran first, T1 releases the add
+    // semaphore via its finally, T2 proceeds) is a legal terminating path, but the
+    // default deadlock-detection heuristic flags the intermediate state.
+    //
+    // To make this test meaningful, the runner needs
+    //   Configuration.Create()
+    //     .WithPotentialDeadlocksReportedAsBugs(false)
+    //     .WithConcurrencyFuzzingEnabled()
+    //     .WithTestingIterations(10_000)
+    // and the invariant needs to assert downstream side effects (CommitAsync vs
+    // RollbackAsync calls on the TransactionManager, counted via an NSubstitute probe)
+    // rather than just terminal enum state. The scaffolding is left in place; the
+    // scheduling-tuning work is tracked as the C1 follow-up in the audit.
+    [Fact(Skip = "Requires Coyote harness tuning — see inline comment and audit C1 follow-up.")]
+    public void CompleteCoreAsync_RacingAbortAsync_ShouldNotThrowOrCorruptState()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                ConsumerPipelineContext context = ConsumerPipelineContextHelper.CreateSubstitute();
+                using TestSequence sequence = new("c1-add-complete-race", context, totalLength: 1);
+
+                Task addPathComplete = Task.Run(
+                    async () => await sequence.TriggerAddPathCompleteAsync().ConfigureAwait(false));
+
+                Task abort = Task.Run(
+                    async () => await sequence
+                        .AbortAsync(SequenceAbortReason.Error, new InvalidOperationException("racing abort"))
+                        .ConfigureAwait(false));
+
+                await Task.WhenAll(addPathComplete, abort).ConfigureAwait(false);
+
+                // Primary invariant: the sequence has reached a terminal state and is
+                // internally consistent. Both flags cannot be true simultaneously since
+                // _completeState is a single enum value, but the test still catches
+                // exceptions thrown during the race (e.g. stream provider rejecting a
+                // follow-up operation because it is already in the opposite state).
+                bool isTerminal = sequence.IsComplete || sequence.IsAborted;
+                bool notBoth = !(sequence.IsComplete && sequence.IsAborted);
+                Microsoft.Coyote.Specifications.Specification.Assert(
+                    isTerminal && notBoth,
+                    $"Sequence ended in unexpected state: IsComplete={sequence.IsComplete}, IsAborted={sequence.IsAborted}");
+            },
+            _output);
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/SequenceStoreConcurrencyTests.cs
+++ b/tests/Silverback.Tests.Concurrency/SequenceStoreConcurrencyTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NSubstitute;
+using Silverback.Messaging.Sequences;
+using Silverback.Tests.Types;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Silverback.Tests.Concurrency;
+
+// Audit finding H1 — SequenceStore is a plain Dictionary<string, ISequence> with zero
+// synchronization. Cross-thread callers exist today: the main channel thread calls
+// AddAsync / GetAsync during pipeline flow, while the SequenceBase timeout timer task,
+// external abort paths, and disposal all call RemoveAsync or enumerate the store from
+// a different thread.
+//
+// The test reproduces the race by concurrently adding a new entry while enumerating the
+// store. The underlying Dictionary's enumerator has a version check that throws
+// InvalidOperationException("Collection was modified...") if it observes a mutation
+// across MoveNext calls. Coyote's scheduler can reliably interleave the mutation between
+// the two MoveNext calls that bracket an `await Task.Yield()` in the enumerator task.
+//
+// Expected: this test fails on master (InvalidOperationException bubbles out of
+// Task.WhenAll). Fix direction: wrap _store in a lock, or switch the backing field to
+// ConcurrentDictionary. See audit H1.
+public class SequenceStoreConcurrencyTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public SequenceStoreConcurrencyTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void SequenceStore_EnumerateWhileAdding_ShouldNotThrow()
+    {
+        CoyoteTestRunner.Run(
+            async () =>
+            {
+                SequenceStore store = new(new SilverbackLoggerSubstitute<SequenceStore>());
+
+                // Seed with one entry so the enumerator actually iterates and hits a
+                // subsequent MoveNext after the race-inducing yield.
+                ISequence seed = Substitute.For<ISequence>();
+                seed.SequenceId.Returns("seed");
+                await store.AddAsync(seed).ConfigureAwait(false);
+
+                ISequence newSequence = Substitute.For<ISequence>();
+                newSequence.SequenceId.Returns("added-concurrently");
+
+                // T1: add a new entry. AddAsync is async but synchronous in this path
+                // (the await-AbortAsync branch is only taken when the key already exists).
+                Task add = Task.Run(
+                    async () => await store.AddAsync(newSequence).ConfigureAwait(false));
+
+                // T2: enumerate the store. An `await Task.Yield()` between MoveNext calls
+                // gives Coyote a scheduling point at which to interleave the mutation.
+                Task enumerate = Task.Run(
+                    async () =>
+                    {
+                        using IEnumerator<ISequence> enumerator = store.GetEnumerator();
+                        while (enumerator.MoveNext())
+                        {
+                            await Task.Yield();
+                        }
+                    });
+
+                await Task.WhenAll(add, enumerate).ConfigureAwait(false);
+            },
+            _output);
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/Silverback.Tests.Concurrency.csproj
+++ b/tests/Silverback.Tests.Concurrency/Silverback.Tests.Concurrency.csproj
@@ -1,0 +1,55 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(TestsTargetFrameworks)</TargetFrameworks>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <RootNamespace>Silverback.Tests.Concurrency</RootNamespace>
+    <LangVersion>$(LangVersion)</LangVersion>
+    <!--
+      Analyzers produce a lot of noise in Coyote test code (intentional sync-over-async,
+      Task.Run inside test bodies, etc.). Keep them off to mirror how Coyote samples ship.
+    -->
+    <AnalysisMode>None</AnalysisMode>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CA1707;CA2007;VSTHRD002;VSTHRD003;VSTHRD200;SA0001;SA1600;SA1633</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Coyote" />
+    <PackageReference Include="Microsoft.Coyote.Test" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Silverback.Integration\Silverback.Integration.csproj" />
+    <ProjectReference Include="..\..\src\Silverback.Integration.Kafka\Silverback.Integration.Kafka.csproj" />
+    <ProjectReference Include="..\Silverback.Tests.Common.Integration\Silverback.Tests.Common.Integration.csproj" />
+    <ProjectReference Include="..\Silverback.Tests.Common\Silverback.Tests.Common.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="rewrite.coyote.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\xunit.runner.json">
+      <Link>xunit.runner.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <!--
+    After build, invoke `coyote rewrite` on the test output directory so that xunit picks up
+    rewritten Silverback.* and test assemblies. DOTNET_ROLL_FORWARD=Major is needed because
+    Microsoft.Coyote.CLI 1.7.11 ships as net8.0 and this solution targets net10.0 only.
+  -->
+  <Target Name="CoyoteRewrite" AfterTargets="Build" Condition="'$(SkipCoyoteRewrite)' != 'true'">
+    <Message Text="Running coyote rewrite against $(OutputPath)" Importance="high" />
+    <Exec Command="coyote rewrite &quot;$(MSBuildProjectDirectory)\rewrite.coyote.json&quot;"
+          WorkingDirectory="$(MSBuildProjectDirectory)"
+          EnvironmentVariables="DOTNET_ROLL_FORWARD=Major" />
+  </Target>
+</Project>

--- a/tests/Silverback.Tests.Concurrency/Silverback.Tests.Concurrency.csproj
+++ b/tests/Silverback.Tests.Concurrency/Silverback.Tests.Concurrency.csproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Silverback.Integration\Silverback.Integration.csproj" />
     <ProjectReference Include="..\..\src\Silverback.Integration.Kafka\Silverback.Integration.Kafka.csproj" />
+    <ProjectReference Include="..\..\src\Silverback.Integration.MQTT\Silverback.Integration.MQTT.csproj" />
     <ProjectReference Include="..\Silverback.Tests.Common.Integration\Silverback.Tests.Common.Integration.csproj" />
     <ProjectReference Include="..\Silverback.Tests.Common\Silverback.Tests.Common.csproj" />
   </ItemGroup>

--- a/tests/Silverback.Tests.Concurrency/TestSequence.cs
+++ b/tests/Silverback.Tests.Concurrency/TestSequence.cs
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Sergio Aquilini
+// This code is licensed under MIT license (see LICENSE file for details)
+
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Silverback.Messaging.Broker.Behaviors;
+using Silverback.Messaging.Messages;
+using Silverback.Messaging.Sequences;
+
+namespace Silverback.Tests.Concurrency;
+
+// A minimal concrete SequenceBase for Coyote tests. We subclass RawSequence rather than
+// BatchSequence/ChunkSequence to avoid pulling in the timeout timer (a fire-and-forget
+// Task.Run polling loop) and the chunk-ordering state machine, neither of which is
+// relevant to the completion/abort synchronization we want Coyote to explore.
+//
+// Exposes a couple of reflection-based hooks into SequenceBase<>'s private members so
+// tests can reproduce the exact race conditions described in the audit (notably C1,
+// where AddCoreAsync calls the private CompleteCoreAsync while holding only
+// _addSemaphoreSlim).
+internal sealed class TestSequence : RawSequence
+{
+    private static readonly MethodInfo CompleteCoreAsyncMethod =
+        typeof(SequenceBase<IRawInboundEnvelope>)
+            .GetMethod("CompleteCoreAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    private static readonly FieldInfo AddSemaphoreSlimField =
+        typeof(SequenceBase<IRawInboundEnvelope>)
+            .GetField("_addSemaphoreSlim", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    public TestSequence(string sequenceId, ConsumerPipelineContext context, int? totalLength = null)
+        : base(sequenceId, context, enforceTimeout: false)
+    {
+        if (totalLength.HasValue)
+        {
+            TotalLength = totalLength.Value;
+        }
+    }
+
+    // Mimics what AddCoreAsync does at its tail when Length == TotalLength: acquire
+    // _addSemaphoreSlim and then call the private CompleteCoreAsync directly WITHOUT
+    // acquiring _completeSemaphoreSlim. This is the exact race pattern from audit
+    // finding C1: the public CompleteAsync wrapper guards against racing with
+    // AbortAsync via _completeSemaphoreSlim, but the inlined call from AddCoreAsync
+    // bypasses that guard.
+    public async Task TriggerAddPathCompleteAsync()
+    {
+        SemaphoreSlim addSemaphore = (SemaphoreSlim)AddSemaphoreSlimField.GetValue(this)!;
+        await addSemaphore.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            ValueTask task = (ValueTask)CompleteCoreAsyncMethod
+                .Invoke(this, new object[] { default(CancellationToken) })!;
+            await task.ConfigureAwait(false);
+        }
+        finally
+        {
+            addSemaphore.Release();
+        }
+    }
+}

--- a/tests/Silverback.Tests.Concurrency/rewrite.coyote.json
+++ b/tests/Silverback.Tests.Concurrency/rewrite.coyote.json
@@ -1,0 +1,11 @@
+{
+  "AssembliesPath": "bin/Debug/net10.0",
+  "Assemblies": [
+    "Silverback.Core.dll",
+    "Silverback.Integration.dll",
+    "Silverback.Integration.Kafka.dll",
+    "Silverback.Tests.Concurrency.dll"
+  ],
+  "IsRewritingThreads": true,
+  "IsRewritingConcurrentCollections": true
+}

--- a/tests/Silverback.Tests.Concurrency/rewrite.coyote.json
+++ b/tests/Silverback.Tests.Concurrency/rewrite.coyote.json
@@ -4,6 +4,7 @@
     "Silverback.Core.dll",
     "Silverback.Integration.dll",
     "Silverback.Integration.Kafka.dll",
+    "Silverback.Integration.MQTT.dll",
     "Silverback.Tests.Concurrency.dll"
   ],
   "IsRewritingThreads": true,


### PR DESCRIPTION
## Summary

Two E2E stress tests using the mocked broker infrastructure that hammer the full Silverback pipeline under high concurrency. These are regular xunit tests (no Coyote) that live in the existing E2E project and run the real consumer pipeline end-to-end.

Designed to surface the concurrency bugs found in PR #263 under realistic load conditions. Expected to fail on the current codebase.

Run with:
    dotnet test tests/Silverback.Integration.Tests.E2E -c Debug --filter "Type=Stress"

## Tests

### KafkaBatchStressTests (60s timeout)

- 24 partitions, batch size 50, 5040 messages
- Sync IMessageStreamEnumerable subscriber (24 threads blocked in MoveNext via SafeWait)
- Messages distributed via SetKafkaKey across all partitions
- Asserts: all 5040 consumed, no duplicates, all offsets committed

Bugs this surfaces under load:
- **C3**: ConsumerChannelsManager semaphore leak after partition count fluctuation
- **H1**: SequenceStore unsynchronized Dictionary under 24 concurrent readers/writers
- **AbortIfIncompleteAsync**: semaphore leak on incomplete batch abort
- **Thread starvation**: 24 sync subscribers exhaust the ThreadPool

### MqttConcurrencyStressTests (60s timeout)

- 1200 messages produced concurrently via Task.WhenAll
- Sync subscriber with Thread.SpinWait(100) to maximize callback overlap
- Asserts: all 1200 received, no duplicates, no missing indices

Bugs this surfaces under load:
- **MC1**: _nextChannelIndex non-atomic increment in OnMessageReceivedAsync
- **MC2**: publish queue channel recreation race under rapid production

## Test plan

- [ ] dotnet build tests/Silverback.Integration.Tests.E2E -- no errors
- [ ] dotnet test --filter "Type=Stress" -- expected: both tests fail (timeout or assertion)
- [ ] dotnet test --filter "Type=E2E" -- existing E2E tests still pass (stress tests are isolated by Trait)