### PR TITLE
fix: Ensure tombstones do not poison cached keys

### DIFF
--- a/src/Silverback.Core/Messaging/Subscribers/SubscribedMethodsCache.cs
+++ b/src/Silverback.Core/Messaging/Subscribers/SubscribedMethodsCache.cs
@@ -14,9 +14,9 @@ namespace Silverback.Messaging.Subscribers;
 
 internal sealed class SubscribedMethodsCache
 {
-    private readonly ConcurrentDictionary<Type, IReadOnlyList<SubscribedMethod>> _exclusiveMethodsCache = [];
+    private readonly ConcurrentDictionary<(Type, bool), IReadOnlyList<SubscribedMethod>> _exclusiveMethodsCache = [];
 
-    private readonly ConcurrentDictionary<Type, IReadOnlyList<SubscribedMethod>> _nonExclusiveMethodsCache = [];
+    private readonly ConcurrentDictionary<(Type, bool), IReadOnlyList<SubscribedMethod>> _nonExclusiveMethodsCache = [];
 
     private readonly ConcurrentDictionary<Type, bool> _hasMessageStreamSubscriber = [];
 
@@ -93,10 +93,18 @@ internal sealed class SubscribedMethodsCache
         (subscribedMethod.MessageType.IsAssignableFrom(envelope.MessageType) ||
          subscribedMethod.MessageType.IsInstanceOfType(envelope));
 
+    // Tombstone envelopes (Message == null) and regular envelopes share the same CLR type
+    // (e.g. InboundEnvelope<T>), but AreCompatible behaves differently for each because it
+    // branches on envelope.Message != null. A shared cache key would mean whichever arrives
+    // first permanently determines the compatible-method set for the other, causing poisoning.
+    // Including the tombstone flag in the key gives each its own correctly computed entry.
+    private static (Type Type, bool IsTombstone) GetCacheKey(object message) =>
+        (message.GetType(), message is IEnvelope { Message: null });
+
     private IReadOnlyList<SubscribedMethod> GetMethods(object message, bool exclusive, IServiceProvider serviceProvider) =>
         (exclusive ? _exclusiveMethodsCache : _nonExclusiveMethodsCache)
         .GetOrAdd(
-            message.GetType(),
+            GetCacheKey(message),
             static (_, args) =>
             [
                 .. args.Instance.GetAllSubscribedMethods(args.ServiceProvider)

--- a/tests/Silverback.Integration.Tests.E2E/Kafka/NullMessageHandlingTests.cs
+++ b/tests/Silverback.Integration.Tests.E2E/Kafka/NullMessageHandlingTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Sergio Aquilini
 // This code is licensed under MIT license (see LICENSE file for details)
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
@@ -224,5 +225,64 @@ public class NullMessageHandlingTests : KafkaTests
         consumedEnvelope.ShouldNotBeNull();
         consumedEnvelope!.GetKafkaKey().ShouldBe("42");
         consumedEnvelope!.Message.ShouldBeNull();
+    }
+
+    /// <summary>
+    ///     Regression test for SubscribedMethodsCache poisoning by tombstone-first messages.
+    ///
+    ///     When a compacted/state topic is consumed from the earliest offset, tombstone records often
+    ///     appear before the corresponding regular records. The cache key is the envelope CLR type
+    ///     (<c>InboundEnvelope&lt;T&gt;</c>), but <c>AreCompatible</c> is instance-dependent (it branches on
+    ///     <c>envelope.Message != null</c>). If a tombstone is seen first, only the tombstone handler is
+    ///     stored in the cache; subsequent regular messages reuse that stale entry and their typed subscriber
+    ///     is never invoked, which causes an <see cref="UnhandledMessageException" /> and stops the consumer.
+    /// </summary>
+    [Fact]
+    public async Task TombstoneFirst_ThenRegularMessage_ShouldInvokeBothSubscribers()
+    {
+        int received = 0;
+        int tombstonesReceived = 0;
+
+        await Host.ConfigureServicesAndRunAsync(services => services
+            .AddLogging()
+            .AddSilverback()
+            .WithConnectionToMessageBroker(options => options.AddMockedKafka())
+            .AddKafkaClients(clients => clients
+                .WithBootstrapServers("PLAINTEXT://e2e")
+                .AddConsumer(consumer => consumer
+                    .WithGroupId(DefaultGroupId)
+                    .Consume<TestEventOne>(endpoint => endpoint.ConsumeFrom(DefaultTopicName))))
+            .AddDelegateSubscriber<TestEventOne>(_ => received++)
+            .AddDelegateSubscriber<Tombstone<TestEventOne>>(_ => tombstonesReceived++)
+            .AddIntegrationSpy());
+
+        IProducer producer = Helper.GetProducerForEndpoint(DefaultTopicName);
+
+        // Tombstone arrives first — simulates reading a compacted state topic from the earliest offset
+        // where a key was previously deleted. This is the scenario that poisons the cache on buggy code.
+        await producer.RawProduceAsync(
+            (byte[]?)null,
+            new MessageHeaderCollection { { KafkaMessageHeaders.MessageKey, "key-1" } });
+
+        await Helper.WaitUntilAllMessagesAreConsumedAsync();
+        tombstonesReceived.ShouldBe(1);
+
+        // A regular (non-tombstone) message for the same type now arrives.
+        // On buggy code: the cache is poisoned — only the Tombstone handler is in the cached set,
+        // TombstoneMessageArgumentResolver.GetValue returns null (not a tombstone), SkipInvocationIfNull
+        // skips the invocation, no handler runs, ThrowIfUnhandled fires and stops the consumer.
+        // On fixed code: the cache correctly resolves both handlers per-message-instance.
+        await producer.ProduceAsync(
+            new TestEventOne(),
+            new MessageHeaderCollection { { KafkaMessageHeaders.MessageKey, "key-1" } });
+
+        // Use a short timeout so the test fails fast on buggy code (consumer stops → offset never
+        // committed → the default 30 s wait would time out). throwTimeoutException:false lets us
+        // fall through to the assertions which produce a clean failure.
+        await Helper.WaitUntilAllMessagesAreConsumedAsync(throwTimeoutException: false, TimeSpan.FromSeconds(3));
+
+        Helper.Spy.InboundEnvelopes.Count.ShouldBe(2);
+        tombstonesReceived.ShouldBe(1);
+        received.ShouldBe(1);
     }
 }


### PR DESCRIPTION
“No subscriber could be found” after Silverback 5 migration

No subscriber could be found to handle the message of type
Silverback.Messaging.Messages.InboundEnvelope`1[[Ch.Post.App.Nes.Masterdata.Route.V1.Route, ...]]
Affects all Masterdata topics (Route, ReceptacleType, IMPC, DispatchSeriesLookup).

Root Cause: SubscribedMethodsCache Poisoning Caused by Tombstones

Silverback 5 caches the subscriber matching based on message.GetType() in SubscribedMethodsCache:

// Silverback.Core → SubscribedMethodsCache.cs
.GetOrAdd(
    message.GetType(),   // Cache key = type, e.g., InboundEnvelope<Route>
    static (_, args) =>
        args.Instance.GetAllSubscribedMethods(args.ServiceProvider)
            .Where(subscribedMethod => AreCompatible(args.Message, subscribedMethod) && ...)
    ...);
However, the compatibility check (AreCompatible) is instance-dependent:

// Check 2 -> only if Message != null
if (message is IEnvelope { Message: not null } envelope
    && subscribedMethod.MessageType.IsAssignableFrom(envelope.MessageType))
    return true;

// Check 3 -> Fallback: Type check on the envelope itself
if (subscribedMethod.MessageType.IsInstanceOfType(message))
    return true;
https://github.com/BEagle1984/silverback/blob/2a809161fb541c50879b244234343bf96f782c24/src/Silverback.Core/Messaging/Subscribers/SubscribedMethodsCache.cs#L40-L65

The Problem

Tombstones and regular messages have the same .NET type (InboundEnvelope<Route>),
but different Message values (null vs. Route instance).

The cache is populated only once per type (by the first message of that type).

Scenario: The first message is a tombstone (Message = null)

Cache for InboundEnvelope<Route> => DeleteAsync only

All subsequent regular messages of the same type:

Use the cache → find only DeleteAsync() //
TombstoneMessageArgumentResolver.GetValue() checks envelope.IsTombstone → false → returns null
SkipInvocationIfNull = true → method is skipped
No method was called → ThrowIfUnhandled = true (new default in v5) → Exception!
Why Only Masterdata Topics?

Masterdata topics are condensed state topics. When reading from Offset.Earliest,
tombstones typically appear as the first messages → the cache is populated incorrectly.

This happens especially during Cypress tests (especially for the route), because we perform cleanups first